### PR TITLE
Upgrade to prettier 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "yarn test && yarn build",
     "clean": "rm -rf dist",
     "build": "yarn clean && tsc",
-    "test": "jest"
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
   },
   "keywords": [
     "prettier",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "plugin"
   ],
   "dependencies": {
-    "prettier": "^2.8.2",
+    "prettier": "^3.0.3",
     "sql-parser-cst": "^0.17.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prepublishOnly": "yarn test && yarn build",
     "clean": "rm -rf dist",
     "build": "yarn clean && tsc",
-    "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest)",
+    "pretty": "prettier -w src/"
   },
   "keywords": [
     "prettier",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "devDependencies": {
     "@types/jest": "^29.2.5",
     "dedent-js": "^1.0.1",
-    "jest": "^29.3.1",
-    "ts-jest": "^29.0.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "typescript": "^4.9.4"
   }
 }

--- a/src/CstToDocMap.ts
+++ b/src/CstToDocMap.ts
@@ -9,7 +9,7 @@ export type ToDocFn<TNode> = (
   print: PrintFn<TNode>,
   node: TNode,
   path: AstPath<TNode>,
-  options: AllPrettierOptions<TNode>
+  options: AllPrettierOptions<TNode>,
 ) => Doc;
 
 export type CstToDocMap<TNode extends Node> = {

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,8 +1,8 @@
-import { Printer } from "prettier";
-import { Node } from "sql-parser-cst";
-import { embedJs } from "./embedJs";
-import { embedJson } from "./embedJson";
+// import { Printer } from "prettier";
+// import { Node } from "sql-parser-cst";
+// import { embedJs } from "./embedJs";
+// import { embedJson } from "./embedJson";
 
-export const embed: NonNullable<Printer<Node>["embed"]> = (...args) => {
-  return embedJson(...args) || embedJs(...args);
-};
+// export const embed: NonNullable<Printer<Node>["embed"]> = (...args) => {
+//   return embedJson(...args) || embedJs(...args);
+// };

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,8 +1,8 @@
-// import { Printer } from "prettier";
-// import { Node } from "sql-parser-cst";
-// import { embedJs } from "./embedJs";
-// import { embedJson } from "./embedJson";
+import { Printer } from "prettier";
+import { Node } from "sql-parser-cst";
+import { embedJs } from "./embedJs";
+import { embedJson } from "./embedJson";
 
-// export const embed: NonNullable<Printer<Node>["embed"]> = (...args) => {
-//   return embedJson(...args) || embedJs(...args);
-// };
+export const embed: NonNullable<Printer<Node>["embed"]> = (...args) => {
+  return embedJson(...args) || embedJs(...args);
+};

--- a/src/embedJs.ts
+++ b/src/embedJs.ts
@@ -1,62 +1,62 @@
-import { Printer } from "prettier";
-import { CreateFunctionStmt, Node } from "sql-parser-cst";
-import {
-  isAsClause,
-  isCreateFunctionStmt,
-  isLanguageClause,
-  isStringLiteral,
-} from "./node_utils";
-import { hardline, indent, stripTrailingHardline } from "./print_utils";
+// import { Printer } from "prettier";
+// import { CreateFunctionStmt, Node } from "sql-parser-cst";
+// import {
+//   isAsClause,
+//   isCreateFunctionStmt,
+//   isLanguageClause,
+//   isStringLiteral,
+// } from "./node_utils";
+// import { hardline, indent, stripTrailingHardline } from "./print_utils";
 
-export const embedJs: NonNullable<Printer<Node>["embed"]> = (
-  path,
-  print,
-  textToDoc,
-  options
-) => {
-  const node = path.getValue();
-  const parent = path.getParentNode(0);
-  const grandParent = path.getParentNode(1);
-  if (
-    isStringLiteral(node) &&
-    isAsClause(parent) &&
-    isCreateFunctionStmt(grandParent) &&
-    grandParent.clauses.some(isJavaScriptLanguageClause)
-  ) {
-    const quotes = detectQuotes(node.value);
-    if (!quotes) {
-      // Give up for now. Don't format JavaScript inside the string.
-      // Perhaps tackle this corner-case in the future.
-      return null;
-    }
+// export const embedJs: NonNullable<Printer<Node>["embed"]> = (
+//   path,
+//   print,
+//   textToDoc,
+//   options
+// ) => {
+//   const node = path.getValue();
+//   const parent = path.getParentNode(0);
+//   const grandParent = path.getParentNode(1);
+//   if (
+//     isStringLiteral(node) &&
+//     isAsClause(parent) &&
+//     isCreateFunctionStmt(grandParent) &&
+//     grandParent.clauses.some(isJavaScriptLanguageClause)
+//   ) {
+//     const quotes = detectQuotes(node.value);
+//     if (!quotes) {
+//       // Give up for now. Don't format JavaScript inside the string.
+//       // Perhaps tackle this corner-case in the future.
+//       return null;
+//     }
 
-    const js = textToDoc(node.value, {
-      ...options,
-      parser: "babel",
-    });
+//     const js = textToDoc(node.value, {
+//       ...options,
+//       parser: "babel",
+//     });
 
-    return [
-      quotes[0],
-      indent([hardline, stripTrailingHardline(js)]),
-      hardline,
-      quotes[1],
-    ];
-  }
-  return null;
-};
+//     return [
+//       quotes[0],
+//       indent([hardline, stripTrailingHardline(js)]),
+//       hardline,
+//       quotes[1],
+//     ];
+//   }
+//   return null;
+// };
 
-const isJavaScriptLanguageClause = (
-  clause: CreateFunctionStmt["clauses"][0]
-): boolean => isLanguageClause(clause) && clause.name.name === "js";
+// const isJavaScriptLanguageClause = (
+//   clause: CreateFunctionStmt["clauses"][0]
+// ): boolean => isLanguageClause(clause) && clause.name.name === "js";
 
-// Whether to quote the code with single- or double-quotes.
-// Returns undefined when neither can be used without escaping.
-const detectQuotes = (js: string): [string, string] | undefined => {
-  if (!/'''/.test(js)) {
-    return ["r'''", "'''"];
-  }
-  if (!/"""/.test(js)) {
-    return ['r"""', '"""'];
-  }
-  return undefined;
-};
+// // Whether to quote the code with single- or double-quotes.
+// // Returns undefined when neither can be used without escaping.
+// const detectQuotes = (js: string): [string, string] | undefined => {
+//   if (!/'''/.test(js)) {
+//     return ["r'''", "'''"];
+//   }
+//   if (!/"""/.test(js)) {
+//     return ['r"""', '"""'];
+//   }
+//   return undefined;
+// };

--- a/src/embedJs.ts
+++ b/src/embedJs.ts
@@ -1,62 +1,57 @@
-// import { Printer } from "prettier";
-// import { CreateFunctionStmt, Node } from "sql-parser-cst";
-// import {
-//   isAsClause,
-//   isCreateFunctionStmt,
-//   isLanguageClause,
-//   isStringLiteral,
-// } from "./node_utils";
-// import { hardline, indent, stripTrailingHardline } from "./print_utils";
+import { Printer } from "prettier";
+import { CreateFunctionStmt, Node } from "sql-parser-cst";
+import {
+  isAsClause,
+  isCreateFunctionStmt,
+  isLanguageClause,
+  isStringLiteral,
+} from "./node_utils";
+import { hardline, indent, stripTrailingHardline } from "./print_utils";
 
-// export const embedJs: NonNullable<Printer<Node>["embed"]> = (
-//   path,
-//   print,
-//   textToDoc,
-//   options
-// ) => {
-//   const node = path.getValue();
-//   const parent = path.getParentNode(0);
-//   const grandParent = path.getParentNode(1);
-//   if (
-//     isStringLiteral(node) &&
-//     isAsClause(parent) &&
-//     isCreateFunctionStmt(grandParent) &&
-//     grandParent.clauses.some(isJavaScriptLanguageClause)
-//   ) {
-//     const quotes = detectQuotes(node.value);
-//     if (!quotes) {
-//       // Give up for now. Don't format JavaScript inside the string.
-//       // Perhaps tackle this corner-case in the future.
-//       return null;
-//     }
+export const embedJs: NonNullable<Printer<Node>["embed"]> = () => async (textToDoc, print, path, options) => {
+  const node = path.getValue(); // TODO: Don't use deprecated method
+  const parent = path.getParentNode(0);
+  const grandParent = path.getParentNode(1);
+  if (
+    isStringLiteral(node) &&
+    isAsClause(parent) &&
+    isCreateFunctionStmt(grandParent) &&
+    grandParent.clauses.some(isJavaScriptLanguageClause)
+  ) {
+    const quotes = detectQuotes(node.value);
+    if (!quotes) {
+      // Give up for now. Don't format JavaScript inside the string.
+      // Perhaps tackle this corner-case in the future.
+      return undefined;
+    }
 
-//     const js = textToDoc(node.value, {
-//       ...options,
-//       parser: "babel",
-//     });
+    const js = await textToDoc(node.value, {
+      ...options,
+      parser: "babel",
+    });
 
-//     return [
-//       quotes[0],
-//       indent([hardline, stripTrailingHardline(js)]),
-//       hardline,
-//       quotes[1],
-//     ];
-//   }
-//   return null;
-// };
+    return [
+      quotes[0],
+      indent([hardline, stripTrailingHardline(js)]),
+      hardline,
+      quotes[1],
+    ];
+  }
+  return undefined;
+};
 
-// const isJavaScriptLanguageClause = (
-//   clause: CreateFunctionStmt["clauses"][0]
-// ): boolean => isLanguageClause(clause) && clause.name.name === "js";
+const isJavaScriptLanguageClause = (
+  clause: CreateFunctionStmt["clauses"][0]
+): boolean => isLanguageClause(clause) && clause.name.name === "js";
 
-// // Whether to quote the code with single- or double-quotes.
-// // Returns undefined when neither can be used without escaping.
-// const detectQuotes = (js: string): [string, string] | undefined => {
-//   if (!/'''/.test(js)) {
-//     return ["r'''", "'''"];
-//   }
-//   if (!/"""/.test(js)) {
-//     return ['r"""', '"""'];
-//   }
-//   return undefined;
-// };
+// Whether to quote the code with single- or double-quotes.
+// Returns undefined when neither can be used without escaping.
+const detectQuotes = (js: string): [string, string] | undefined => {
+  if (!/'''/.test(js)) {
+    return ["r'''", "'''"];
+  }
+  if (!/"""/.test(js)) {
+    return ['r"""', '"""'];
+  }
+  return undefined;
+};

--- a/src/embedJs.ts
+++ b/src/embedJs.ts
@@ -37,13 +37,13 @@ export const embedJs: NonNullable<Printer<Node>["embed"]> = (path, options) => {
         hardline,
         quotes[1],
       ];
-    }
+    };
   }
   return null;
 };
 
 const isJavaScriptLanguageClause = (
-  clause: CreateFunctionStmt["clauses"][0]
+  clause: CreateFunctionStmt["clauses"][0],
 ): boolean => isLanguageClause(clause) && clause.name.name === "js";
 
 // Whether to quote the code with single- or double-quotes.

--- a/src/embedJson.ts
+++ b/src/embedJson.ts
@@ -8,32 +8,34 @@ import {
   stripTrailingHardline,
 } from "./print_utils";
 
-export const embedJson: NonNullable<Printer<Node>["embed"]> = () => async (textToDoc, print, path, options) => {
+export const embedJson: NonNullable<Printer<Node>["embed"]> = (path, options) => {
   const node = path.getValue(); // TODO: Don't use deprecated method
   const parent = path.getParentNode();
   if (isStringLiteral(node) && isJsonLiteral(parent)) {
-    if (
-      containsTripleQuote(node.value) ||
-      containsBackslash(node.value) ||
-      isRawString(node)
-    ) {
-      // Give up for now. Don't format JSON inside the string.
-      // Tackle these corner-case in the future.
-      return undefined;
+    return async (textToDoc) => {
+      if (
+        containsTripleQuote(node.value) ||
+        containsBackslash(node.value) ||
+        isRawString(node)
+      ) {
+        // Give up for now. Don't format JSON inside the string.
+        // Tackle these corner-case in the future.
+        return undefined;
+      }
+      const json = await textToDoc(node.value, {
+        ...options,
+        parser: "json",
+      });
+      const inlineQuote = containsSingleQuote(node.value) ? "'''" : "'";
+      return [
+        ifBreak("'''", inlineQuote),
+        indent([softline, stripTrailingHardline(json)]),
+        softline,
+        ifBreak("'''", inlineQuote),
+      ];
     }
-    const json = await textToDoc(node.value, {
-      ...options,
-      parser: "json",
-    });
-    const inlineQuote = containsSingleQuote(node.value) ? "'''" : "'";
-    return [
-      ifBreak("'''", inlineQuote),
-      indent([softline, stripTrailingHardline(json)]),
-      softline,
-      ifBreak("'''", inlineQuote),
-    ];
   }
-  return undefined;
+  return null;
 };
 
 const containsSingleQuote = (json: string) => /'/.test(json);

--- a/src/embedJson.ts
+++ b/src/embedJson.ts
@@ -1,48 +1,43 @@
-// import { Printer } from "prettier";
-// import { Node, StringLiteral } from "sql-parser-cst";
-// import { isJsonLiteral, isStringLiteral } from "./node_utils";
-// import {
-//   ifBreak,
-//   indent,
-//   softline,
-//   stripTrailingHardline,
-// } from "./print_utils";
+import { Printer } from "prettier";
+import { Node, StringLiteral } from "sql-parser-cst";
+import { isJsonLiteral, isStringLiteral } from "./node_utils";
+import {
+  ifBreak,
+  indent,
+  softline,
+  stripTrailingHardline,
+} from "./print_utils";
 
-// export const embedJson: NonNullable<Printer<Node>["embed"]> = (
-//   path,
-//   print,
-//   textToDoc,
-//   options
-// ) => {
-//   const node = path.getValue();
-//   const parent = path.getParentNode();
-//   if (isStringLiteral(node) && isJsonLiteral(parent)) {
-//     if (
-//       containsTripleQuote(node.value) ||
-//       containsBackslash(node.value) ||
-//       isRawString(node)
-//     ) {
-//       // Give up for now. Don't format JSON inside the string.
-//       // Tackle these corner-case in the future.
-//       return null;
-//     }
-//     const json = textToDoc(node.value, {
-//       ...options,
-//       parser: "json",
-//     });
-//     const inlineQuote = containsSingleQuote(node.value) ? "'''" : "'";
-//     return [
-//       ifBreak("'''", inlineQuote),
-//       indent([softline, stripTrailingHardline(json)]),
-//       softline,
-//       ifBreak("'''", inlineQuote),
-//     ];
-//   }
-//   return null;
-// };
+export const embedJson: NonNullable<Printer<Node>["embed"]> = () => async (textToDoc, print, path, options) => {
+  const node = path.getValue(); // TODO: Don't use deprecated method
+  const parent = path.getParentNode();
+  if (isStringLiteral(node) && isJsonLiteral(parent)) {
+    if (
+      containsTripleQuote(node.value) ||
+      containsBackslash(node.value) ||
+      isRawString(node)
+    ) {
+      // Give up for now. Don't format JSON inside the string.
+      // Tackle these corner-case in the future.
+      return undefined;
+    }
+    const json = await textToDoc(node.value, {
+      ...options,
+      parser: "json",
+    });
+    const inlineQuote = containsSingleQuote(node.value) ? "'''" : "'";
+    return [
+      ifBreak("'''", inlineQuote),
+      indent([softline, stripTrailingHardline(json)]),
+      softline,
+      ifBreak("'''", inlineQuote),
+    ];
+  }
+  return undefined;
+};
 
-// const containsSingleQuote = (json: string) => /'/.test(json);
+const containsSingleQuote = (json: string) => /'/.test(json);
 
-// const containsTripleQuote = (json: string) => /'''/.test(json);
-// const containsBackslash = (json: string) => /\\/.test(json);
-// const isRawString = (node: StringLiteral) => /^R/i.test(node.text);
+const containsTripleQuote = (json: string) => /'''/.test(json);
+const containsBackslash = (json: string) => /\\/.test(json);
+const isRawString = (node: StringLiteral) => /^R/i.test(node.text);

--- a/src/embedJson.ts
+++ b/src/embedJson.ts
@@ -8,7 +8,10 @@ import {
   stripTrailingHardline,
 } from "./print_utils";
 
-export const embedJson: NonNullable<Printer<Node>["embed"]> = (path, options) => {
+export const embedJson: NonNullable<Printer<Node>["embed"]> = (
+  path,
+  options,
+) => {
   const node = path.getValue(); // TODO: Don't use deprecated method
   const parent = path.getParentNode();
   if (isStringLiteral(node) && isJsonLiteral(parent)) {
@@ -33,7 +36,7 @@ export const embedJson: NonNullable<Printer<Node>["embed"]> = (path, options) =>
         softline,
         ifBreak("'''", inlineQuote),
       ];
-    }
+    };
   }
   return null;
 };

--- a/src/embedJson.ts
+++ b/src/embedJson.ts
@@ -1,48 +1,48 @@
-import { Printer } from "prettier";
-import { Node, StringLiteral } from "sql-parser-cst";
-import { isJsonLiteral, isStringLiteral } from "./node_utils";
-import {
-  ifBreak,
-  indent,
-  softline,
-  stripTrailingHardline,
-} from "./print_utils";
+// import { Printer } from "prettier";
+// import { Node, StringLiteral } from "sql-parser-cst";
+// import { isJsonLiteral, isStringLiteral } from "./node_utils";
+// import {
+//   ifBreak,
+//   indent,
+//   softline,
+//   stripTrailingHardline,
+// } from "./print_utils";
 
-export const embedJson: NonNullable<Printer<Node>["embed"]> = (
-  path,
-  print,
-  textToDoc,
-  options
-) => {
-  const node = path.getValue();
-  const parent = path.getParentNode();
-  if (isStringLiteral(node) && isJsonLiteral(parent)) {
-    if (
-      containsTripleQuote(node.value) ||
-      containsBackslash(node.value) ||
-      isRawString(node)
-    ) {
-      // Give up for now. Don't format JSON inside the string.
-      // Tackle these corner-case in the future.
-      return null;
-    }
-    const json = textToDoc(node.value, {
-      ...options,
-      parser: "json",
-    });
-    const inlineQuote = containsSingleQuote(node.value) ? "'''" : "'";
-    return [
-      ifBreak("'''", inlineQuote),
-      indent([softline, stripTrailingHardline(json)]),
-      softline,
-      ifBreak("'''", inlineQuote),
-    ];
-  }
-  return null;
-};
+// export const embedJson: NonNullable<Printer<Node>["embed"]> = (
+//   path,
+//   print,
+//   textToDoc,
+//   options
+// ) => {
+//   const node = path.getValue();
+//   const parent = path.getParentNode();
+//   if (isStringLiteral(node) && isJsonLiteral(parent)) {
+//     if (
+//       containsTripleQuote(node.value) ||
+//       containsBackslash(node.value) ||
+//       isRawString(node)
+//     ) {
+//       // Give up for now. Don't format JSON inside the string.
+//       // Tackle these corner-case in the future.
+//       return null;
+//     }
+//     const json = textToDoc(node.value, {
+//       ...options,
+//       parser: "json",
+//     });
+//     const inlineQuote = containsSingleQuote(node.value) ? "'''" : "'";
+//     return [
+//       ifBreak("'''", inlineQuote),
+//       indent([softline, stripTrailingHardline(json)]),
+//       softline,
+//       ifBreak("'''", inlineQuote),
+//     ];
+//   }
+//   return null;
+// };
 
-const containsSingleQuote = (json: string) => /'/.test(json);
+// const containsSingleQuote = (json: string) => /'/.test(json);
 
-const containsTripleQuote = (json: string) => /'''/.test(json);
-const containsBackslash = (json: string) => /\\/.test(json);
-const isRawString = (node: StringLiteral) => /^R/i.test(node.text);
+// const containsTripleQuote = (json: string) => /'''/.test(json);
+// const containsBackslash = (json: string) => /\\/.test(json);
+// const isRawString = (node: StringLiteral) => /^R/i.test(node.text);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { DialectName, Node, parse } from "sql-parser-cst";
 import { Parser, Printer, SupportLanguage } from "prettier";
 import { printSql } from "./printSql";
 import { printComment } from "./printComment";
-import { embedJson } from "./embedJson";
+import { embed } from "./embed";
 import { isNode } from "./utils";
 import { transformCst } from "./transform/transformCst";
 import { AllPrettierOptions } from "./options";
@@ -47,7 +47,7 @@ export const parsers: Record<string, Parser<Node>> = {
 export const printers: Record<string, Printer> = {
   "sql-cst": {
     print: printSql as Printer["print"],
-    embed: embedJson,
+    embed: embed,
     printComment: printComment,
     canAttachComment: isNode,
     isBlockComment: (node) => node.type === "block_comment",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { DialectName, Node, parse } from "sql-parser-cst";
 import { Parser, Printer, SupportLanguage } from "prettier";
 import { printSql } from "./printSql";
 import { printComment } from "./printComment";
-//import { embed } from "./embed";
+import { embedJson } from "./embedJson";
 import { isNode } from "./utils";
 import { transformCst } from "./transform/transformCst";
 import { AllPrettierOptions } from "./options";
@@ -47,7 +47,7 @@ export const parsers: Record<string, Parser<Node>> = {
 export const printers: Record<string, Printer> = {
   "sql-cst": {
     print: printSql as Printer["print"],
-//    embed: embed,
+    embed: embedJson,
     printComment: printComment,
     canAttachComment: isNode,
     isBlockComment: (node) => node.type === "block_comment",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { DialectName, Node, parse } from "sql-parser-cst";
 import { Parser, Printer, SupportLanguage } from "prettier";
 import { printSql } from "./printSql";
 import { printComment } from "./printComment";
-import { embed } from "./embed";
+//import { embed } from "./embed";
 import { isNode } from "./utils";
 import { transformCst } from "./transform/transformCst";
 import { AllPrettierOptions } from "./options";
@@ -47,7 +47,7 @@ export const parsers: Record<string, Parser<Node>> = {
 export const printers: Record<string, Printer> = {
   "sql-cst": {
     print: printSql as Printer["print"],
-    embed: embed,
+//    embed: embed,
     printComment: printComment,
     canAttachComment: isNode,
     isBlockComment: (node) => node.type === "block_comment",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export const languages: SupportLanguage[] = [
 ];
 
 const createParser = (dialect: DialectName): Parser<Node> => ({
-  parse: (text, parsers, options) =>
+  parse: (text, options) =>
     transformCst(
       parse(text, {
         dialect,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const createParser = (dialect: DialectName): Parser<Node> => ({
         filename: options.filepath,
         paramTypes: (options as AllPrettierOptions<Node>).sqlParamTypes,
       }),
-      text
+      text,
     ),
   astFormat: "sql-cst",
   locStart: (node) => node.range?.[0] as number,

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,25 +13,25 @@ export const options: SupportOptions = {
   sqlKeywordCase: {
     type: "choice",
     category: "SQL",
-    since: "0.1.0",
     default: "upper",
     description: "Enforces upper/lower case for SQL keywords",
     choices: [
       {
         value: "preserve",
         description: "preserves the existing case",
+        since: "0.1.0",
       },
-      { value: "upper", description: "forces all keywords to uppercase" },
-      { value: "lower", description: "forces all keywords to lowercase" },
+      { value: "upper", description: "forces all keywords to uppercase", since: "0.1.0", },
+      { value: "lower", description: "forces all keywords to lowercase", since: "0.1.0", },
     ],
   },
   sqlParamTypes: {
     type: "string",
     array: true,
     category: "SQL",
-    since: "0.7.0",
     default: [{ value: [] }],
     description: "Syntax for bound parameters",
+    // Since 0.7.0
     // Possible values in array: "?" | "?nr" | ":name" | "$name" | "@name"
   },
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,8 +21,16 @@ export const options: SupportOptions = {
         description: "preserves the existing case",
         since: "0.1.0",
       },
-      { value: "upper", description: "forces all keywords to uppercase", since: "0.1.0", },
-      { value: "lower", description: "forces all keywords to lowercase", since: "0.1.0", },
+      {
+        value: "upper",
+        description: "forces all keywords to uppercase",
+        since: "0.1.0",
+      },
+      {
+        value: "lower",
+        description: "forces all keywords to lowercase",
+        since: "0.1.0",
+      },
     ],
   },
   sqlParamTypes: {

--- a/src/printSql.ts
+++ b/src/printSql.ts
@@ -10,7 +10,7 @@ import { join } from "./print_utils";
 export function printSql(
   path: AstPath<Node>,
   options: AllPrettierOptions,
-  oldPrint: OldPrintFn
+  oldPrint: OldPrintFn,
 ): Doc {
   return printNode(path, options, createPrintFn(path, oldPrint));
 }
@@ -20,7 +20,7 @@ let cachedPath: AstPath<Node>;
 
 function createPrintFn(
   path: AstPath<Node>,
-  oldPrint: OldPrintFn
+  oldPrint: OldPrintFn,
 ): PrintFn<Node> {
   // The path parameter will reference the same AstPath instance
   // during the whole printing cycle.
@@ -41,7 +41,7 @@ function createPrintFn(
   }) as PrintFn<Node>;
 
   cachedPrintFn.spaced = (
-    selector: PrintableKey<Node> | PrintableKey<Node>[]
+    selector: PrintableKey<Node> | PrintableKey<Node>[],
   ): Doc[] => {
     const node = path.getValue();
     const docs = arrayWrap(selector)
@@ -60,7 +60,7 @@ function createPrintFn(
 function printNode(
   path: AstPath<Node>,
   options: AllPrettierOptions,
-  print: PrintFn<Node>
+  print: PrintFn<Node>,
 ): Doc {
   const node = path.getValue();
 

--- a/src/print_utils.ts
+++ b/src/print_utils.ts
@@ -24,7 +24,7 @@ export const join = (sep: Doc, docs: Doc): Doc =>
 /** True when the Node contains a newline in original source code */
 export const containsNewline = (
   node: Node,
-  opts: { originalText: string }
+  opts: { originalText: string },
 ): boolean => {
   if (!node.range) {
     throw new Error("containsNewline() expected a Node with range info");
@@ -32,20 +32,20 @@ export const containsNewline = (
   return util.hasNewlineInRange(
     opts.originalText,
     node.range[0],
-    node.range[1]
+    node.range[1],
   );
 };
 
 export const hasEmptyLineBetweenNodes = (
   node1: Node,
   node2: Node,
-  opts: { originalText: string }
+  opts: { originalText: string },
 ): boolean => {
   if (!node1.range || !node2.range) {
     throw new Error("emptyLineBetweenNodes() expects Nodes with range info");
   }
 
   return /\n[ \t]*\r?\n/.test(
-    opts.originalText.slice(node1.range[1], node2.range[0])
+    opts.originalText.slice(node1.range[1], node2.range[0]),
   );
 };

--- a/src/syntax/constraint.ts
+++ b/src/syntax/constraint.ts
@@ -51,7 +51,7 @@ export const constraintMap: Partial<CstToDocMap<AllConstraintNodes>> = {
 
 const printUnnamedConstraint = <T>(
   print: PrintFn<Constraint<T>>,
-  node: Constraint<T>
+  node: Constraint<T>,
 ): Doc => {
   if (node.deferrable) {
     return group([

--- a/src/syntax/function.ts
+++ b/src/syntax/function.ts
@@ -21,7 +21,7 @@ export const functionMap: Partial<CstToDocMap<AllFunctionNodes>> = {
           hardline,
           join(
             hardline,
-            print("clauses").map((cls) => group(cls))
+            print("clauses").map((cls) => group(cls)),
           ),
         ],
   ],

--- a/src/syntax/procedure.ts
+++ b/src/syntax/procedure.ts
@@ -15,7 +15,7 @@ export const procedureMap: Partial<CstToDocMap<AllProcedureNodes>> = {
     hardline,
     join(
       hardline,
-      print("clauses").map((clause) => group(clause))
+      print("clauses").map((clause) => group(clause)),
     ),
   ],
   procedure_param: (print) => print.spaced(["mode", "name", "dataType"]),

--- a/src/syntax/program.ts
+++ b/src/syntax/program.ts
@@ -7,7 +7,7 @@ import { AllPrettierOptions } from "src/options";
 export const programMap: CstToDocMap<Program> = {
   program: (print, node, path, options) =>
     print("statements").map((doc, i) =>
-      printStatement(doc, i, node.statements, options)
+      printStatement(doc, i, node.statements, options),
     ),
 };
 
@@ -15,7 +15,7 @@ const printStatement = (
   doc: Doc,
   i: number,
   statements: Node[],
-  options: AllPrettierOptions<Program>
+  options: AllPrettierOptions<Program>,
 ): Doc => {
   const prevNode = statements[i - 1];
   const node = statements[i];

--- a/src/syntax/select.ts
+++ b/src/syntax/select.ts
@@ -56,7 +56,7 @@ export const selectMap: Partial<CstToDocMap<AllSelectNodes>> = {
                 ? indent([line, print(["specification"])])
                 : [],
             ],
-          ])
+          ]),
         ),
       ];
     }
@@ -74,7 +74,7 @@ export const selectMap: Partial<CstToDocMap<AllSelectNodes>> = {
         group(print("aggregations")),
         print.spaced(["forKw", "inputColumn"]),
         print.spaced(["inKw", "pivotColumns"]),
-      ])
+      ]),
     ),
   unpivot_expr: (print, node) => [
     print("left"),
@@ -91,7 +91,7 @@ export const selectMap: Partial<CstToDocMap<AllSelectNodes>> = {
         print("valuesColumn"),
         print.spaced(["forKw", "nameColumn"]),
         print.spaced(["inKw", "unpivotColumns"]),
-      ])
+      ]),
     ),
   tablesample_expr: (print) =>
     group([print("left"), line, print.spaced(["tablesampleKw", "args"])]),
@@ -141,15 +141,15 @@ export const selectMap: Partial<CstToDocMap<AllSelectNodes>> = {
     return group(
       join(
         lineType,
-        print(["baseWindowName", "partitionBy", "orderBy", "frame"])
-      )
+        print(["baseWindowName", "partitionBy", "orderBy", "frame"]),
+      ),
     );
   },
 };
 
 const printLimitValues = (
   print: PrintFn<LimitClause>,
-  node: LimitClause
+  node: LimitClause,
 ): Doc => {
   if (node.offsetKw) {
     return print.spaced(["count", "offsetKw", "offset"]);

--- a/src/transform/addFinalSemicolon.ts
+++ b/src/transform/addFinalSemicolon.ts
@@ -4,7 +4,7 @@ import { last } from "../utils";
 
 export const addFinalSemicolon = (
   program: Program,
-  originalText: string
+  originalText: string,
 ): Program => {
   if (!isEmpty(last(program.statements))) {
     const end = originalText.length;

--- a/src/transform/comments.ts
+++ b/src/transform/comments.ts
@@ -8,7 +8,7 @@ import { visitAllNodes } from "../visitAllNodes";
  * Deletes the .leading and .trailing fields of all nodes.
  */
 export const moveCommentsToRoot = (
-  cst: Program
+  cst: Program,
 ): Program & { comments: Whitespace[] } => {
   return {
     ...cst,

--- a/src/transform/transformCst.ts
+++ b/src/transform/transformCst.ts
@@ -9,5 +9,5 @@ import { addFinalSemicolon } from "./addFinalSemicolon";
 export const transformCst = (cst: Program, originalText: string): Program =>
   addFinalSemicolon(
     stripTrailingCommas(processAliasAs(moveCommentsToRoot(cst))),
-    originalText
+    originalText,
   );

--- a/test/alias.test.ts
+++ b/test/alias.test.ts
@@ -2,8 +2,8 @@ import dedent from "dedent-js";
 import { pretty, test } from "./test_utils";
 
 describe("aliases", () => {
-  it(`formats aliases`, () => {
-    test(
+  it(`formats aliases`, async () => {
+    await test(
       dedent`
         SELECT
           1 AS a,
@@ -14,8 +14,8 @@ describe("aliases", () => {
     );
   });
 
-  it(`converts implicit aliases to use AS keyword`, () => {
-    expect(pretty(`SELECT 1 AS foo, 2 bar FROM client c, tbl AS t`))
+  it(`converts implicit aliases to use AS keyword`, async () => {
+    expect(await pretty(`SELECT 1 AS foo, 2 bar FROM client c, tbl AS t`))
       .toBe(dedent`
         SELECT 1 AS foo, 2 AS bar
         FROM

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -1,11 +1,11 @@
 import { test } from "./test_utils";
 
 describe("analyze", () => {
-  it(`formats ANALYZE statement`, () => {
+  it(`formats ANALYZE statement`, async () => {
     test(`ANALYZE my_schema.my_table`);
   });
 
-  it(`formats plain ANALYZE statement`, () => {
+  it(`formats plain ANALYZE statement`, async () => {
     test(`ANALYZE`);
   });
 });

--- a/test/analyze.test.ts
+++ b/test/analyze.test.ts
@@ -2,10 +2,10 @@ import { test } from "./test_utils";
 
 describe("analyze", () => {
   it(`formats ANALYZE statement`, async () => {
-    test(`ANALYZE my_schema.my_table`);
+    await test(`ANALYZE my_schema.my_table`);
   });
 
   it(`formats plain ANALYZE statement`, async () => {
-    test(`ANALYZE`);
+    await test(`ANALYZE`);
   });
 });

--- a/test/bigquery/bigquery.test.ts
+++ b/test/bigquery/bigquery.test.ts
@@ -4,23 +4,23 @@ import { testBigquery } from "../test_utils";
 describe("bigquery", () => {
   ["CAPACITY", "RESERVATION", "ASSIGNMENT"].forEach((entityType) => {
     it(`formats CREATE ${entityType}`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE ${entityType} commitment_id
         OPTIONS (slot_count = 100, plan = 'FLEX')
       `);
     });
 
     it(`formats DROP ${entityType}`, async () => {
-      testBigquery(`DROP ${entityType} commitment_id`);
+      await testBigquery(`DROP ${entityType} commitment_id`);
     });
 
     it(`formats DROP ${entityType} IF EXISTS`, async () => {
-      testBigquery(`DROP ${entityType} IF EXISTS commitment_id`);
+      await testBigquery(`DROP ${entityType} IF EXISTS commitment_id`);
     });
   });
 
   it(`formats ALTER ORGANIZATION`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       ALTER ORGANIZATION
       SET OPTIONS (default_time_zone = 'America/Los_Angeles')
     `);
@@ -29,7 +29,7 @@ describe("bigquery", () => {
   ["PROJECT", "BI_CAPACITY", "CAPACITY", "RESERVATION"].forEach(
     (entityType) => {
       it(`formats ALTER ${entityType}`, async () => {
-        testBigquery(dedent`
+        await testBigquery(dedent`
         ALTER ${entityType} some_name
         SET OPTIONS (default_time_zone = 'America/Los_Angeles')
       `);
@@ -39,13 +39,13 @@ describe("bigquery", () => {
 
   describe("assert", () => {
     it(`formats ASSERT`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         ASSERT x > 10
       `);
     });
 
     it(`formats ASSERT with message`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         ASSERT x > 10 AS 'x must be greater than 10'
       `);
     });

--- a/test/bigquery/bigquery.test.ts
+++ b/test/bigquery/bigquery.test.ts
@@ -3,23 +3,23 @@ import { testBigquery } from "../test_utils";
 
 describe("bigquery", () => {
   ["CAPACITY", "RESERVATION", "ASSIGNMENT"].forEach((entityType) => {
-    it(`formats CREATE ${entityType}`, () => {
+    it(`formats CREATE ${entityType}`, async () => {
       testBigquery(dedent`
         CREATE ${entityType} commitment_id
         OPTIONS (slot_count = 100, plan = 'FLEX')
       `);
     });
 
-    it(`formats DROP ${entityType}`, () => {
+    it(`formats DROP ${entityType}`, async () => {
       testBigquery(`DROP ${entityType} commitment_id`);
     });
 
-    it(`formats DROP ${entityType} IF EXISTS`, () => {
+    it(`formats DROP ${entityType} IF EXISTS`, async () => {
       testBigquery(`DROP ${entityType} IF EXISTS commitment_id`);
     });
   });
 
-  it(`formats ALTER ORGANIZATION`, () => {
+  it(`formats ALTER ORGANIZATION`, async () => {
     testBigquery(dedent`
       ALTER ORGANIZATION
       SET OPTIONS (default_time_zone = 'America/Los_Angeles')
@@ -28,7 +28,7 @@ describe("bigquery", () => {
 
   ["PROJECT", "BI_CAPACITY", "CAPACITY", "RESERVATION"].forEach(
     (entityType) => {
-      it(`formats ALTER ${entityType}`, () => {
+      it(`formats ALTER ${entityType}`, async () => {
         testBigquery(dedent`
         ALTER ${entityType} some_name
         SET OPTIONS (default_time_zone = 'America/Los_Angeles')
@@ -38,13 +38,13 @@ describe("bigquery", () => {
   );
 
   describe("assert", () => {
-    it(`formats ASSERT`, () => {
+    it(`formats ASSERT`, async () => {
       testBigquery(dedent`
         ASSERT x > 10
       `);
     });
 
-    it(`formats ASSERT with message`, () => {
+    it(`formats ASSERT with message`, async () => {
       testBigquery(dedent`
         ASSERT x > 10 AS 'x must be greater than 10'
       `);

--- a/test/bigquery/export_and_load.test.ts
+++ b/test/bigquery/export_and_load.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("export & load", () => {
-  it(`formats EXPORT DATA`, () => {
+  it(`formats EXPORT DATA`, async () => {
     testBigquery(dedent`
       EXPORT DATA
       OPTIONS (uri = 'gs://bucket/folder/*.csv', format = 'CSV')
@@ -11,7 +11,7 @@ describe("export & load", () => {
     `);
   });
 
-  it(`formats EXPORT DATA with CONNECTION`, () => {
+  it(`formats EXPORT DATA with CONNECTION`, async () => {
     testBigquery(dedent`
       EXPORT DATA
       WITH CONNECTION myproject.us.myconnection
@@ -21,14 +21,14 @@ describe("export & load", () => {
     `);
   });
 
-  it(`formats LOAD DATA`, () => {
+  it(`formats LOAD DATA`, async () => {
     testBigquery(dedent`
       LOAD DATA INTO mydataset.table1
       FROM FILES (format = 'AVRO', uris = ['gs://bucket/path/file.avro'])
     `);
   });
 
-  it(`formats LOAD DATA with columns`, () => {
+  it(`formats LOAD DATA with columns`, async () => {
     testBigquery(dedent`
       LOAD DATA INTO mydataset.table1 (x INT64, y STRING)
       OPTIONS (description = "my table")
@@ -36,7 +36,7 @@ describe("export & load", () => {
     `);
   });
 
-  it(`formats LOAD DATA with long column list`, () => {
+  it(`formats LOAD DATA with long column list`, async () => {
     testBigquery(dedent`
       LOAD DATA INTO mydataset.table1 (
         first_field INT64,
@@ -48,7 +48,7 @@ describe("export & load", () => {
     `);
   });
 
-  it(`formats LOAD DATA with PARTITION/CLUSTER BY & WITH PARTITION COLUMNS & CONNECTION`, () => {
+  it(`formats LOAD DATA with PARTITION/CLUSTER BY & WITH PARTITION COLUMNS & CONNECTION`, async () => {
     testBigquery(dedent`
       LOAD DATA INTO mydataset.table1
       PARTITION BY transaction_date

--- a/test/bigquery/export_and_load.test.ts
+++ b/test/bigquery/export_and_load.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("export & load", () => {
   it(`formats EXPORT DATA`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       EXPORT DATA
       OPTIONS (uri = 'gs://bucket/folder/*.csv', format = 'CSV')
       AS
@@ -12,7 +12,7 @@ describe("export & load", () => {
   });
 
   it(`formats EXPORT DATA with CONNECTION`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       EXPORT DATA
       WITH CONNECTION myproject.us.myconnection
       OPTIONS (uri = 'gs://bucket/folder/*.csv', format = 'CSV')
@@ -22,14 +22,14 @@ describe("export & load", () => {
   });
 
   it(`formats LOAD DATA`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       LOAD DATA INTO mydataset.table1
       FROM FILES (format = 'AVRO', uris = ['gs://bucket/path/file.avro'])
     `);
   });
 
   it(`formats LOAD DATA with columns`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       LOAD DATA INTO mydataset.table1 (x INT64, y STRING)
       OPTIONS (description = "my table")
       FROM FILES (format = 'AVRO', uris = ['gs://bucket/path/file.avro'])
@@ -37,7 +37,7 @@ describe("export & load", () => {
   });
 
   it(`formats LOAD DATA with long column list`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       LOAD DATA INTO mydataset.table1 (
         first_field INT64,
         second_field STRING,
@@ -49,7 +49,7 @@ describe("export & load", () => {
   });
 
   it(`formats LOAD DATA with PARTITION/CLUSTER BY & WITH PARTITION COLUMNS & CONNECTION`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       LOAD DATA INTO mydataset.table1
       PARTITION BY transaction_date
       CLUSTER BY customer_id

--- a/test/bigquery/row_access_policy.test.ts
+++ b/test/bigquery/row_access_policy.test.ts
@@ -4,21 +4,21 @@ import { testBigquery } from "../test_utils";
 describe("row access policy", () => {
   describe("create row access policy", () => {
     it(`formats CREATE ROW ACCESS POLICY`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE ROW ACCESS POLICY policy_name ON my_table
         FILTER USING (x > 10)
       `);
     });
 
     it(`formats OR REPLACE / IF NOT EXISTS`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE OR REPLACE ROW ACCESS POLICY IF NOT EXISTS policy_name ON my_table
         FILTER USING (x > 10)
       `);
     });
 
     it(`formats GRANT TO`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE ROW ACCESS POLICY policy_name ON my_table
         GRANT TO ('user:alice@example.com', 'domain:example.com')
         FILTER USING (x > 10)
@@ -28,19 +28,19 @@ describe("row access policy", () => {
 
   describe("drop row access policy", () => {
     it(`formats DROP ROW ACCESS POLICY`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         DROP ROW ACCESS POLICY policy_name ON my_table
       `);
     });
 
     it(`formats IF EXISTS`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         DROP ROW ACCESS POLICY IF EXISTS policy_name ON my_table
       `);
     });
 
     it(`formats DROP ALL ROW ACCESS POLICIES`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         DROP ALL ROW ACCESS POLICIES ON my_table
       `);
     });

--- a/test/bigquery/row_access_policy.test.ts
+++ b/test/bigquery/row_access_policy.test.ts
@@ -3,21 +3,21 @@ import { testBigquery } from "../test_utils";
 
 describe("row access policy", () => {
   describe("create row access policy", () => {
-    it(`formats CREATE ROW ACCESS POLICY`, () => {
+    it(`formats CREATE ROW ACCESS POLICY`, async () => {
       testBigquery(dedent`
         CREATE ROW ACCESS POLICY policy_name ON my_table
         FILTER USING (x > 10)
       `);
     });
 
-    it(`formats OR REPLACE / IF NOT EXISTS`, () => {
+    it(`formats OR REPLACE / IF NOT EXISTS`, async () => {
       testBigquery(dedent`
         CREATE OR REPLACE ROW ACCESS POLICY IF NOT EXISTS policy_name ON my_table
         FILTER USING (x > 10)
       `);
     });
 
-    it(`formats GRANT TO`, () => {
+    it(`formats GRANT TO`, async () => {
       testBigquery(dedent`
         CREATE ROW ACCESS POLICY policy_name ON my_table
         GRANT TO ('user:alice@example.com', 'domain:example.com')
@@ -27,19 +27,19 @@ describe("row access policy", () => {
   });
 
   describe("drop row access policy", () => {
-    it(`formats DROP ROW ACCESS POLICY`, () => {
+    it(`formats DROP ROW ACCESS POLICY`, async () => {
       testBigquery(dedent`
         DROP ROW ACCESS POLICY policy_name ON my_table
       `);
     });
 
-    it(`formats IF EXISTS`, () => {
+    it(`formats IF EXISTS`, async () => {
       testBigquery(dedent`
         DROP ROW ACCESS POLICY IF EXISTS policy_name ON my_table
       `);
     });
 
-    it(`formats DROP ALL ROW ACCESS POLICIES`, () => {
+    it(`formats DROP ALL ROW ACCESS POLICIES`, async () => {
       testBigquery(dedent`
         DROP ALL ROW ACCESS POLICIES ON my_table
       `);

--- a/test/comments.test.ts
+++ b/test/comments.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { rawPretty, rawTest } from "./test_utils";
 
 describe("comments", () => {
-  it(`formats block comments`, () => {
+  it(`formats block comments`, async () => {
     rawTest(dedent`
       /* leading comment */
       SELECT 1, /*com1*/ 2 /*com2*/;
@@ -11,7 +11,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`formats basic doc-comments`, () => {
+  it(`formats basic doc-comments`, async () => {
     rawTest(dedent`
       /**
        * A large doc-comment comment
@@ -22,7 +22,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`formats block comments between syntax elements`, () => {
+  it(`formats block comments between syntax elements`, async () => {
     rawTest(dedent`
       CREATE /*c1*/ TABLE /*c2*/ IF /*c3*/ NOT EXISTS /*c4*/ foo (
         id /*c5*/ INT /*c6*/ NOT /*c7*/ NULL
@@ -31,7 +31,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`formats line comments`, () => {
+  it(`formats line comments`, async () => {
     rawTest(dedent`
       -- first line comment
       -- second line comment
@@ -41,7 +41,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`moves line comments before comma to line ends`, () => {
+  it(`moves line comments before comma to line ends`, async () => {
     expect(
       rawPretty(`
         SELECT
@@ -58,7 +58,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`formats comments between statements`, () => {
+  it(`formats comments between statements`, async () => {
     rawTest(dedent`
       -- comment for 1
       SELECT 1;
@@ -71,7 +71,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`enforces space between -- and comment text`, () => {
+  it(`enforces space between -- and comment text`, async () => {
     expect(
       rawPretty(`
         --My comment
@@ -84,7 +84,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`enforces space between # and comment text`, () => {
+  it(`enforces space between # and comment text`, async () => {
     expect(
       rawPretty(`
         #My comment
@@ -97,7 +97,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`allows for empty -- comments`, () => {
+  it(`allows for empty -- comments`, async () => {
     rawTest(dedent`
       --
       --
@@ -106,7 +106,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`allows for empty # comments`, () => {
+  it(`allows for empty # comments`, async () => {
     rawTest(dedent`
       #
       #
@@ -115,7 +115,7 @@ describe("comments", () => {
     `);
   });
 
-  it(`preserves #! comments as-is`, () => {
+  it(`preserves #! comments as-is`, async () => {
     rawTest(dedent`
       #!/usr/bin/sqlite
       SELECT 1;
@@ -124,7 +124,7 @@ describe("comments", () => {
   });
 
   // Issue #9
-  it.skip(`keeps separate-line line-comments on a separate line (not moving them to line end)`, () => {
+  it.skip(`keeps separate-line line-comments on a separate line (not moving them to line end)`, async () => {
     rawTest(dedent`
       CREATE TABLE foo
       -- com1

--- a/test/comments.test.ts
+++ b/test/comments.test.ts
@@ -43,7 +43,7 @@ describe("comments", () => {
 
   it(`moves line comments before comma to line ends`, async () => {
     expect(
-      rawPretty(`
+      await rawPretty(`
         SELECT
           1 -- com1
           ,2 -- com2
@@ -73,7 +73,7 @@ describe("comments", () => {
 
   it(`enforces space between -- and comment text`, async () => {
     expect(
-      rawPretty(`
+      await rawPretty(`
         --My comment
         SELECT 1;
       `)
@@ -86,7 +86,7 @@ describe("comments", () => {
 
   it(`enforces space between # and comment text`, async () => {
     expect(
-      rawPretty(`
+      await rawPretty(`
         #My comment
         SELECT 1;
       `)

--- a/test/dcl/grant.test.ts
+++ b/test/dcl/grant.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("grant", () => {
-  it(`formats GRANT (single role, single user)`, () => {
+  it(`formats GRANT (single role, single user)`, async () => {
     testBigquery(dedent`
       GRANT \`roles/bigquery.dataViewer\`
       ON TABLE myCompany.revenue
@@ -10,7 +10,7 @@ describe("grant", () => {
     `);
   });
 
-  it(`formats GRANT (multiple roles, multiple users)`, () => {
+  it(`formats GRANT (multiple roles, multiple users)`, async () => {
     testBigquery(dedent`
       GRANT \`roles/bigquery.dataViewer\`, \`roles/bigquery.admin\`
       ON SCHEMA myCompany
@@ -18,7 +18,7 @@ describe("grant", () => {
     `);
   });
 
-  it(`formats GRANT (multiline list of roles and users)`, () => {
+  it(`formats GRANT (multiline list of roles and users)`, async () => {
     testBigquery(dedent`
       GRANT
         \`roles/bigquery.dataViewer\`,

--- a/test/dcl/grant.test.ts
+++ b/test/dcl/grant.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("grant", () => {
   it(`formats GRANT (single role, single user)`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       GRANT \`roles/bigquery.dataViewer\`
       ON TABLE myCompany.revenue
       TO 'user:tom@example.com'
@@ -11,7 +11,7 @@ describe("grant", () => {
   });
 
   it(`formats GRANT (multiple roles, multiple users)`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       GRANT \`roles/bigquery.dataViewer\`, \`roles/bigquery.admin\`
       ON SCHEMA myCompany
       TO 'user:tom@example.com', 'user:sara@example.com'
@@ -19,7 +19,7 @@ describe("grant", () => {
   });
 
   it(`formats GRANT (multiline list of roles and users)`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       GRANT
         \`roles/bigquery.dataViewer\`,
         \`roles/bigquery.admin\`,

--- a/test/dcl/revoke.test.ts
+++ b/test/dcl/revoke.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("revoke", () => {
   it(`formats REVOKE (single role, single user)`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       REVOKE \`roles/bigquery.dataViewer\`
       ON VIEW myCompany.revenue
       FROM 'user:tom@example.com'
@@ -11,7 +11,7 @@ describe("revoke", () => {
   });
 
   it(`formats REVOKE (multiple roles, multiple users)`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       REVOKE \`roles/bigquery.dataViewer\`, \`roles/bigquery.admin\`
       ON SCHEMA myCompany
       FROM 'user:tom@example.com', 'user:sara@example.com'
@@ -19,7 +19,7 @@ describe("revoke", () => {
   });
 
   it(`formats REVOKE (multiline list of roles and users)`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       REVOKE
         \`roles/bigquery.dataViewer\`,
         \`roles/bigquery.admin\`,

--- a/test/dcl/revoke.test.ts
+++ b/test/dcl/revoke.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("revoke", () => {
-  it(`formats REVOKE (single role, single user)`, () => {
+  it(`formats REVOKE (single role, single user)`, async () => {
     testBigquery(dedent`
       REVOKE \`roles/bigquery.dataViewer\`
       ON VIEW myCompany.revenue
@@ -10,7 +10,7 @@ describe("revoke", () => {
     `);
   });
 
-  it(`formats REVOKE (multiple roles, multiple users)`, () => {
+  it(`formats REVOKE (multiple roles, multiple users)`, async () => {
     testBigquery(dedent`
       REVOKE \`roles/bigquery.dataViewer\`, \`roles/bigquery.admin\`
       ON SCHEMA myCompany
@@ -18,7 +18,7 @@ describe("revoke", () => {
     `);
   });
 
-  it(`formats REVOKE (multiline list of roles and users)`, () => {
+  it(`formats REVOKE (multiline list of roles and users)`, async () => {
     testBigquery(dedent`
       REVOKE
         \`roles/bigquery.dataViewer\`,

--- a/test/ddl/alter_table.test.ts
+++ b/test/ddl/alter_table.test.ts
@@ -2,21 +2,21 @@ import dedent from "dedent-js";
 import { test, testBigquery } from "../test_utils";
 
 describe("alter table", () => {
-  it(`formats ALTER TABLE..RENAME`, () => {
+  it(`formats ALTER TABLE..RENAME`, async () => {
     test(dedent`
       ALTER TABLE client
       RENAME TO org_client
     `);
   });
 
-  it(`formats ALTER TABLE IF EXISTS`, () => {
+  it(`formats ALTER TABLE IF EXISTS`, async () => {
     testBigquery(dedent`
       ALTER TABLE IF EXISTS client
       RENAME TO org_client
     `);
   });
 
-  it(`formats ALTER TABLE..RENAME COLUMN`, () => {
+  it(`formats ALTER TABLE..RENAME COLUMN`, async () => {
     test(dedent`
       ALTER TABLE client
       RENAME col1 TO col2
@@ -27,14 +27,14 @@ describe("alter table", () => {
     `);
   });
 
-  it(`formats ALTER TABLE..RENAME COLUMN IF EXISTS`, () => {
+  it(`formats ALTER TABLE..RENAME COLUMN IF EXISTS`, async () => {
     testBigquery(dedent`
         ALTER TABLE client
         RENAME COLUMN IF EXISTS col1 TO col2
       `);
   });
 
-  it(`formats ALTER TABLE..ADD COLUMN`, () => {
+  it(`formats ALTER TABLE..ADD COLUMN`, async () => {
     test(dedent`
       ALTER TABLE client
       ADD col1 INT
@@ -45,14 +45,14 @@ describe("alter table", () => {
     `);
   });
 
-  it(`formats ALTER TABLE..ADD COLUMN IF NOT EXISTS`, () => {
+  it(`formats ALTER TABLE..ADD COLUMN IF NOT EXISTS`, async () => {
     testBigquery(dedent`
       ALTER TABLE client
       ADD COLUMN IF NOT EXISTS col1 INT
     `);
   });
 
-  it(`formats ALTER TABLE..DROP COLUMN`, () => {
+  it(`formats ALTER TABLE..DROP COLUMN`, async () => {
     test(dedent`
       ALTER TABLE client
       DROP col1
@@ -63,21 +63,21 @@ describe("alter table", () => {
     `);
   });
 
-  it(`formats ALTER TABLE..DROP COLUMN IF EXISTS`, () => {
+  it(`formats ALTER TABLE..DROP COLUMN IF EXISTS`, async () => {
     testBigquery(dedent`
       ALTER TABLE client
       DROP COLUMN IF EXISTS col1
     `);
   });
 
-  it(`formats ALTER TABLE..SET OPTIONS`, () => {
+  it(`formats ALTER TABLE..SET OPTIONS`, async () => {
     testBigquery(dedent`
       ALTER TABLE client
       SET OPTIONS (description = 'Table that expires seven days from now')
     `);
   });
 
-  it(`formats ALTER TABLE..SET DEFAULT COLLATE`, () => {
+  it(`formats ALTER TABLE..SET DEFAULT COLLATE`, async () => {
     testBigquery(dedent`
       ALTER TABLE client
       SET DEFAULT COLLATE 'und:ci'
@@ -85,7 +85,7 @@ describe("alter table", () => {
   });
 
   describe("alter column", () => {
-    it(`formats ALTER COLUMN .. SET OPTIONS`, () => {
+    it(`formats ALTER COLUMN .. SET OPTIONS`, async () => {
       testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN price
@@ -93,7 +93,7 @@ describe("alter table", () => {
       `);
     });
 
-    it(`formats ALTER COLUMN [IF EXISTS] .. SET DEFAULT`, () => {
+    it(`formats ALTER COLUMN [IF EXISTS] .. SET DEFAULT`, async () => {
       testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN IF EXISTS price
@@ -101,7 +101,7 @@ describe("alter table", () => {
       `);
     });
 
-    it(`formats ALTER COLUMN .. DROP DEFAULT`, () => {
+    it(`formats ALTER COLUMN .. DROP DEFAULT`, async () => {
       testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN price
@@ -109,7 +109,7 @@ describe("alter table", () => {
       `);
     });
 
-    it(`formats ALTER COLUMN .. DROP NOT NULL`, () => {
+    it(`formats ALTER COLUMN .. DROP NOT NULL`, async () => {
       testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN price
@@ -117,7 +117,7 @@ describe("alter table", () => {
       `);
     });
 
-    it(`formats ALTER COLUMN .. SET DATA TYPE`, () => {
+    it(`formats ALTER COLUMN .. SET DATA TYPE`, async () => {
       testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN price

--- a/test/ddl/alter_table.test.ts
+++ b/test/ddl/alter_table.test.ts
@@ -3,82 +3,82 @@ import { test, testBigquery } from "../test_utils";
 
 describe("alter table", () => {
   it(`formats ALTER TABLE..RENAME`, async () => {
-    test(dedent`
+    await test(dedent`
       ALTER TABLE client
       RENAME TO org_client
     `);
   });
 
   it(`formats ALTER TABLE IF EXISTS`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       ALTER TABLE IF EXISTS client
       RENAME TO org_client
     `);
   });
 
   it(`formats ALTER TABLE..RENAME COLUMN`, async () => {
-    test(dedent`
+    await test(dedent`
       ALTER TABLE client
       RENAME col1 TO col2
     `);
-    test(dedent`
+    await test(dedent`
       ALTER TABLE client
       RENAME COLUMN col1 TO col2
     `);
   });
 
   it(`formats ALTER TABLE..RENAME COLUMN IF EXISTS`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
         ALTER TABLE client
         RENAME COLUMN IF EXISTS col1 TO col2
       `);
   });
 
   it(`formats ALTER TABLE..ADD COLUMN`, async () => {
-    test(dedent`
+    await test(dedent`
       ALTER TABLE client
       ADD col1 INT
     `);
-    test(dedent`
+    await test(dedent`
       ALTER TABLE client
       ADD COLUMN col1 INT
     `);
   });
 
   it(`formats ALTER TABLE..ADD COLUMN IF NOT EXISTS`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       ALTER TABLE client
       ADD COLUMN IF NOT EXISTS col1 INT
     `);
   });
 
   it(`formats ALTER TABLE..DROP COLUMN`, async () => {
-    test(dedent`
+    await test(dedent`
       ALTER TABLE client
       DROP col1
     `);
-    test(dedent`
+    await test(dedent`
       ALTER TABLE client
       DROP COLUMN col1
     `);
   });
 
   it(`formats ALTER TABLE..DROP COLUMN IF EXISTS`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       ALTER TABLE client
       DROP COLUMN IF EXISTS col1
     `);
   });
 
   it(`formats ALTER TABLE..SET OPTIONS`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       ALTER TABLE client
       SET OPTIONS (description = 'Table that expires seven days from now')
     `);
   });
 
   it(`formats ALTER TABLE..SET DEFAULT COLLATE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       ALTER TABLE client
       SET DEFAULT COLLATE 'und:ci'
     `);
@@ -86,7 +86,7 @@ describe("alter table", () => {
 
   describe("alter column", () => {
     it(`formats ALTER COLUMN .. SET OPTIONS`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN price
         SET OPTIONS (description = 'Price per unit')
@@ -94,7 +94,7 @@ describe("alter table", () => {
     });
 
     it(`formats ALTER COLUMN [IF EXISTS] .. SET DEFAULT`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN IF EXISTS price
         SET DEFAULT 100
@@ -102,7 +102,7 @@ describe("alter table", () => {
     });
 
     it(`formats ALTER COLUMN .. DROP DEFAULT`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN price
         DROP DEFAULT
@@ -110,7 +110,7 @@ describe("alter table", () => {
     });
 
     it(`formats ALTER COLUMN .. DROP NOT NULL`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN price
         DROP NOT NULL
@@ -118,7 +118,7 @@ describe("alter table", () => {
     });
 
     it(`formats ALTER COLUMN .. SET DATA TYPE`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         ALTER TABLE client
         ALTER COLUMN price
         SET DATA TYPE INT64

--- a/test/ddl/create_table.test.ts
+++ b/test/ddl/create_table.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { test, testBigquery } from "../test_utils";
 
 describe("create table", () => {
-  it(`formats CREATE TABLE always on multiple lines`, () => {
+  it(`formats CREATE TABLE always on multiple lines`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INT,
@@ -12,7 +12,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE TEMPORARY TABLE`, () => {
+  it(`formats CREATE TEMPORARY TABLE`, async () => {
     test(dedent`
       CREATE TEMPORARY TABLE foo (
         id INT
@@ -20,7 +20,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats IF NOT EXISTS`, () => {
+  it(`formats IF NOT EXISTS`, async () => {
     test(dedent`
       CREATE TABLE IF NOT EXISTS foo (
         id INT
@@ -28,7 +28,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats OR REPLACE`, () => {
+  it(`formats OR REPLACE`, async () => {
     testBigquery(dedent`
       CREATE OR REPLACE TABLE foo (
         id INT
@@ -36,7 +36,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE TABLE with various data types`, () => {
+  it(`formats CREATE TABLE with various data types`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INTEGER,
@@ -48,7 +48,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE TABLE with column constraints`, () => {
+  it(`formats CREATE TABLE with column constraints`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INT NOT NULL PRIMARY KEY,
@@ -61,7 +61,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats SQLite PRIMARY KEY modifiers`, () => {
+  it(`formats SQLite PRIMARY KEY modifiers`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INTEGER PRIMARY KEY ASC AUTOINCREMENT
@@ -69,7 +69,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE TABLE with table constraints`, () => {
+  it(`formats CREATE TABLE with table constraints`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INT,
@@ -82,7 +82,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats FOREIGN KEY constraint with options`, () => {
+  it(`formats FOREIGN KEY constraint with options`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INT,
@@ -95,7 +95,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats deferrable FOREIGN KEY constraint`, () => {
+  it(`formats deferrable FOREIGN KEY constraint`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INT,
@@ -108,7 +108,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE TABLE with named column constraints`, () => {
+  it(`formats CREATE TABLE with named column constraints`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INT CONSTRAINT NOT NULL CONSTRAINT prim_key PRIMARY KEY
@@ -116,7 +116,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE TABLE with named table constraints`, () => {
+  it(`formats CREATE TABLE with named table constraints`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INT,
@@ -127,7 +127,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats constraints with ON CONFLICT clause`, () => {
+  it(`formats constraints with ON CONFLICT clause`, async () => {
     test(dedent`
       CREATE TABLE client (
         id INT,
@@ -138,7 +138,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats BigQuery data types with internal constraints`, () => {
+  it(`formats BigQuery data types with internal constraints`, async () => {
     testBigquery(dedent`
       CREATE TABLE client (
         arr_field ARRAY<INT64 NOT NULL>,
@@ -149,7 +149,7 @@ describe("create table", () => {
   });
 
   // Issue #10
-  it(`formats long BigQuery struct definition to multiple lines`, () => {
+  it(`formats long BigQuery struct definition to multiple lines`, async () => {
     testBigquery(dedent`
       CREATE TABLE client (
         struct_field STRUCT<
@@ -163,7 +163,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats SQLite table options`, () => {
+  it(`formats SQLite table options`, async () => {
     test(dedent`
       CREATE TABLE foo (
         id INT
@@ -172,7 +172,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats single short BigQuery extra CREATE TABLE clause`, () => {
+  it(`formats single short BigQuery extra CREATE TABLE clause`, async () => {
     testBigquery(dedent`
       CREATE TABLE client (
         id INT64
@@ -181,7 +181,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats additional BigQuery CREATE TABLE clauses`, () => {
+  it(`formats additional BigQuery CREATE TABLE clauses`, async () => {
     testBigquery(dedent`
       CREATE TABLE client (
         id INT64
@@ -193,7 +193,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats long BigQuery OPTIONS ()`, () => {
+  it(`formats long BigQuery OPTIONS ()`, async () => {
     testBigquery(dedent`
       CREATE TABLE client (
         id INT64
@@ -207,14 +207,14 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE TABLE AS`, () => {
+  it(`formats CREATE TABLE AS`, async () => {
     test(dedent`
       CREATE TABLE foo AS
         SELECT * FROM tbl WHERE x > 0
     `);
   });
 
-  it(`formats CREATE TABLE AS with long query`, () => {
+  it(`formats CREATE TABLE AS with long query`, async () => {
     test(dedent`
       CREATE TABLE foo AS
         SELECT column1, column2, column3
@@ -223,35 +223,35 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE TABLE LIKE`, () => {
+  it(`formats CREATE TABLE LIKE`, async () => {
     testBigquery(dedent`
       CREATE TABLE foo
       LIKE my_old_table
     `);
   });
 
-  it(`formats CREATE TABLE COPY`, () => {
+  it(`formats CREATE TABLE COPY`, async () => {
     testBigquery(dedent`
       CREATE TABLE foo
       COPY my_old_table
     `);
   });
 
-  it(`formats CREATE SNAPSHOT TABLE CLONE`, () => {
+  it(`formats CREATE SNAPSHOT TABLE CLONE`, async () => {
     testBigquery(dedent`
       CREATE SNAPSHOT TABLE foo
       CLONE my_old_table
     `);
   });
 
-  it(`formats FOR SYSTEM_TIME AS OF`, () => {
+  it(`formats FOR SYSTEM_TIME AS OF`, async () => {
     testBigquery(dedent`
       CREATE SNAPSHOT TABLE foo
       CLONE my_old_table FOR SYSTEM_TIME AS OF '2017-01-01 10:00:00-07:00'
     `);
   });
 
-  it(`formats CREATE EXTERNAL TABLE`, () => {
+  it(`formats CREATE EXTERNAL TABLE`, async () => {
     testBigquery(dedent`
       CREATE EXTERNAL TABLE dataset.CustomTable (
         id INT64
@@ -262,7 +262,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE EXTERNAL TABLE with long PARTITION COLUMNS list`, () => {
+  it(`formats CREATE EXTERNAL TABLE with long PARTITION COLUMNS list`, async () => {
     testBigquery(dedent`
       CREATE EXTERNAL TABLE dataset.CustomTable
       WITH PARTITION COLUMNS (
@@ -274,7 +274,7 @@ describe("create table", () => {
     `);
   });
 
-  it(`formats CREATE VIRTUAL TABLE`, () => {
+  it(`formats CREATE VIRTUAL TABLE`, async () => {
     test(dedent`
       CREATE VIRTUAL TABLE my_table
       USING my_func(1, 2)

--- a/test/ddl/create_table.test.ts
+++ b/test/ddl/create_table.test.ts
@@ -3,7 +3,7 @@ import { test, testBigquery } from "../test_utils";
 
 describe("create table", () => {
   it(`formats CREATE TABLE always on multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INT,
         name VARCHAR(100),
@@ -13,7 +13,7 @@ describe("create table", () => {
   });
 
   it(`formats CREATE TEMPORARY TABLE`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TEMPORARY TABLE foo (
         id INT
       )
@@ -21,7 +21,7 @@ describe("create table", () => {
   });
 
   it(`formats IF NOT EXISTS`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE IF NOT EXISTS foo (
         id INT
       )
@@ -29,7 +29,7 @@ describe("create table", () => {
   });
 
   it(`formats OR REPLACE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE OR REPLACE TABLE foo (
         id INT
       )
@@ -37,7 +37,7 @@ describe("create table", () => {
   });
 
   it(`formats CREATE TABLE with various data types`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INTEGER,
         name VARCHAR(100),
@@ -49,7 +49,7 @@ describe("create table", () => {
   });
 
   it(`formats CREATE TABLE with column constraints`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INT NOT NULL PRIMARY KEY,
         name VARCHAR(100) UNIQUE COLLATE RTRIM,
@@ -62,7 +62,7 @@ describe("create table", () => {
   });
 
   it(`formats SQLite PRIMARY KEY modifiers`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INTEGER PRIMARY KEY ASC AUTOINCREMENT
       )
@@ -70,7 +70,7 @@ describe("create table", () => {
   });
 
   it(`formats CREATE TABLE with table constraints`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INT,
         name VARCHAR,
@@ -83,7 +83,7 @@ describe("create table", () => {
   });
 
   it(`formats FOREIGN KEY constraint with options`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INT,
         FOREIGN KEY (org_id1) REFERENCES organization (id1)
@@ -96,7 +96,7 @@ describe("create table", () => {
   });
 
   it(`formats deferrable FOREIGN KEY constraint`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INT,
         CONSTRAINT fkey
@@ -109,7 +109,7 @@ describe("create table", () => {
   });
 
   it(`formats CREATE TABLE with named column constraints`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INT CONSTRAINT NOT NULL CONSTRAINT prim_key PRIMARY KEY
       )
@@ -117,7 +117,7 @@ describe("create table", () => {
   });
 
   it(`formats CREATE TABLE with named table constraints`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INT,
         CONSTRAINT prim_key PRIMARY KEY (id, name),
@@ -128,7 +128,7 @@ describe("create table", () => {
   });
 
   it(`formats constraints with ON CONFLICT clause`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE client (
         id INT,
         name VARCHAR(100) NOT NULL ON CONFLICT FAIL,
@@ -139,7 +139,7 @@ describe("create table", () => {
   });
 
   it(`formats BigQuery data types with internal constraints`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE TABLE client (
         arr_field ARRAY<INT64 NOT NULL>,
         struct_field STRUCT<name STRING NOT NULL, age INT64 DEFAULT 0>,
@@ -150,7 +150,7 @@ describe("create table", () => {
 
   // Issue #10
   it(`formats long BigQuery struct definition to multiple lines`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE TABLE client (
         struct_field STRUCT<
           first_name STRING,
@@ -164,7 +164,7 @@ describe("create table", () => {
   });
 
   it(`formats SQLite table options`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE foo (
         id INT
       )
@@ -173,7 +173,7 @@ describe("create table", () => {
   });
 
   it(`formats single short BigQuery extra CREATE TABLE clause`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE TABLE client (
         id INT64
       )
@@ -182,7 +182,7 @@ describe("create table", () => {
   });
 
   it(`formats additional BigQuery CREATE TABLE clauses`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE TABLE client (
         id INT64
       )
@@ -194,7 +194,7 @@ describe("create table", () => {
   });
 
   it(`formats long BigQuery OPTIONS ()`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE TABLE client (
         id INT64
       )
@@ -208,14 +208,14 @@ describe("create table", () => {
   });
 
   it(`formats CREATE TABLE AS`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE foo AS
         SELECT * FROM tbl WHERE x > 0
     `);
   });
 
   it(`formats CREATE TABLE AS with long query`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE TABLE foo AS
         SELECT column1, column2, column3
         FROM external_client
@@ -224,35 +224,35 @@ describe("create table", () => {
   });
 
   it(`formats CREATE TABLE LIKE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE TABLE foo
       LIKE my_old_table
     `);
   });
 
   it(`formats CREATE TABLE COPY`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE TABLE foo
       COPY my_old_table
     `);
   });
 
   it(`formats CREATE SNAPSHOT TABLE CLONE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE SNAPSHOT TABLE foo
       CLONE my_old_table
     `);
   });
 
   it(`formats FOR SYSTEM_TIME AS OF`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE SNAPSHOT TABLE foo
       CLONE my_old_table FOR SYSTEM_TIME AS OF '2017-01-01 10:00:00-07:00'
     `);
   });
 
   it(`formats CREATE EXTERNAL TABLE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE EXTERNAL TABLE dataset.CustomTable (
         id INT64
       )
@@ -263,7 +263,7 @@ describe("create table", () => {
   });
 
   it(`formats CREATE EXTERNAL TABLE with long PARTITION COLUMNS list`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CREATE EXTERNAL TABLE dataset.CustomTable
       WITH PARTITION COLUMNS (
         first_name STRING,
@@ -275,7 +275,7 @@ describe("create table", () => {
   });
 
   it(`formats CREATE VIRTUAL TABLE`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE VIRTUAL TABLE my_table
       USING my_func(1, 2)
     `);

--- a/test/ddl/drop_table.test.ts
+++ b/test/ddl/drop_table.test.ts
@@ -2,18 +2,18 @@ import { test, testBigquery } from "../test_utils";
 
 describe("drop table", () => {
   it(`formats DROP TABLE statement`, async () => {
-    test(`DROP TABLE client`);
+    await test(`DROP TABLE client`);
   });
 
   it(`formats IF EXISTS`, async () => {
-    test(`DROP TABLE IF EXISTS schm.client`);
+    await test(`DROP TABLE IF EXISTS schm.client`);
   });
 
   it(`formats DROP SNAPSHOT table`, async () => {
-    testBigquery(`DROP SNAPSHOT TABLE foo`);
+    await testBigquery(`DROP SNAPSHOT TABLE foo`);
   });
 
   it(`formats DROP EXTERNAL table`, async () => {
-    testBigquery(`DROP EXTERNAL TABLE foo`);
+    await testBigquery(`DROP EXTERNAL TABLE foo`);
   });
 });

--- a/test/ddl/drop_table.test.ts
+++ b/test/ddl/drop_table.test.ts
@@ -1,19 +1,19 @@
 import { test, testBigquery } from "../test_utils";
 
 describe("drop table", () => {
-  it(`formats DROP TABLE statement`, () => {
+  it(`formats DROP TABLE statement`, async () => {
     test(`DROP TABLE client`);
   });
 
-  it(`formats IF EXISTS`, () => {
+  it(`formats IF EXISTS`, async () => {
     test(`DROP TABLE IF EXISTS schm.client`);
   });
 
-  it(`formats DROP SNAPSHOT table`, () => {
+  it(`formats DROP SNAPSHOT table`, async () => {
     testBigquery(`DROP SNAPSHOT TABLE foo`);
   });
 
-  it(`formats DROP EXTERNAL table`, () => {
+  it(`formats DROP EXTERNAL table`, async () => {
     testBigquery(`DROP EXTERNAL TABLE foo`);
   });
 });

--- a/test/ddl/function.test.ts
+++ b/test/ddl/function.test.ts
@@ -4,14 +4,14 @@ import { pretty, testBigquery } from "../test_utils";
 describe("function", () => {
   describe("create function", () => {
     it(`formats CREATE FUNCTION`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
           CREATE FUNCTION my_func(arg1 INT64, arg2 STRING, arg3 ANY TYPE) AS
             (SELECT * FROM client)
         `);
     });
 
     it(`formats long parameter list to multiple lines`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE FUNCTION my_func(
           first_name STRING,
           last_name STRING,
@@ -22,28 +22,28 @@ describe("function", () => {
     });
 
     it(`formats CREATE TEMP FUNCTION`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE TEMPORARY FUNCTION my_func() AS
           (SELECT 1)
       `);
     });
 
     it(`formats OR REPLACE`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE OR REPLACE FUNCTION my_func() AS
           (SELECT 1)
       `);
     });
 
     it(`formats IF NOT EXISTS`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE FUNCTION IF NOT EXISTS my_func() AS
           (SELECT 1)
       `);
     });
 
     it(`formats RETURNS clause`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE FUNCTION IF NOT EXISTS my_func()
         RETURNS INT64
         AS
@@ -52,7 +52,7 @@ describe("function", () => {
     });
 
     it(`formats OPTIONS (...)`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE FUNCTION IF NOT EXISTS my_func()
         AS
           (SELECT 1)
@@ -61,7 +61,7 @@ describe("function", () => {
     });
 
     it(`formats CREATE TABLE FUNCTION`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE TABLE FUNCTION my_func()
         RETURNS TABLE<id INT, name STRING>
         AS
@@ -70,7 +70,7 @@ describe("function", () => {
     });
 
     it(`formats creation of remote function`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE FUNCTION my_func()
         RETURNS INT64
         REMOTE WITH CONNECTION us.myconnection
@@ -79,7 +79,7 @@ describe("function", () => {
     });
 
     it(`formats JavaScript FUNCTION`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE FUNCTION gen_random()
         RETURNS FLOAT64
         NOT DETERMINISTIC
@@ -92,7 +92,7 @@ describe("function", () => {
 
     it(`reformats JavaScript in JS function`, async () => {
       expect(
-        pretty(
+        await pretty(
           dedent`
             CREATE FUNCTION gen_random()
             RETURNS FLOAT64
@@ -115,7 +115,7 @@ describe("function", () => {
 
     it(`quotes JavaScript in double-quotes when single-quotes can't be used`, async () => {
       expect(
-        pretty(
+        await pretty(
           dedent`
             CREATE FUNCTION contains_quotes(x STRING)
             RETURNS FLOAT64
@@ -136,7 +136,7 @@ describe("function", () => {
 
     it(`does not reformat JavaScript when neither ''' or """ can be easily used for quoting`, async () => {
       expect(
-        pretty(
+        await pretty(
           dedent`
             CREATE FUNCTION contains_quotes(x STRING)
             RETURNS FLOAT64
@@ -156,13 +156,13 @@ describe("function", () => {
 
   describe("drop function", () => {
     it(`formats DROP FUNCTION`, async () => {
-      testBigquery(`DROP FUNCTION my_schema.my_func`);
+      await testBigquery(`DROP FUNCTION my_schema.my_func`);
     });
     it(`formats DROP TABLE FUNCTION`, async () => {
-      testBigquery(`DROP TABLE FUNCTION my_func`);
+      await testBigquery(`DROP TABLE FUNCTION my_func`);
     });
     it(`formats IF EXISTS`, async () => {
-      testBigquery(`DROP FUNCTION IF EXISTS my_func`);
+      await testBigquery(`DROP FUNCTION IF EXISTS my_func`);
     });
   });
 });

--- a/test/ddl/function.test.ts
+++ b/test/ddl/function.test.ts
@@ -3,14 +3,14 @@ import { pretty, testBigquery } from "../test_utils";
 
 describe("function", () => {
   describe("create function", () => {
-    it(`formats CREATE FUNCTION`, () => {
+    it(`formats CREATE FUNCTION`, async () => {
       testBigquery(dedent`
           CREATE FUNCTION my_func(arg1 INT64, arg2 STRING, arg3 ANY TYPE) AS
             (SELECT * FROM client)
         `);
     });
 
-    it(`formats long parameter list to multiple lines`, () => {
+    it(`formats long parameter list to multiple lines`, async () => {
       testBigquery(dedent`
         CREATE FUNCTION my_func(
           first_name STRING,
@@ -21,28 +21,28 @@ describe("function", () => {
       `);
     });
 
-    it(`formats CREATE TEMP FUNCTION`, () => {
+    it(`formats CREATE TEMP FUNCTION`, async () => {
       testBigquery(dedent`
         CREATE TEMPORARY FUNCTION my_func() AS
           (SELECT 1)
       `);
     });
 
-    it(`formats OR REPLACE`, () => {
+    it(`formats OR REPLACE`, async () => {
       testBigquery(dedent`
         CREATE OR REPLACE FUNCTION my_func() AS
           (SELECT 1)
       `);
     });
 
-    it(`formats IF NOT EXISTS`, () => {
+    it(`formats IF NOT EXISTS`, async () => {
       testBigquery(dedent`
         CREATE FUNCTION IF NOT EXISTS my_func() AS
           (SELECT 1)
       `);
     });
 
-    it(`formats RETURNS clause`, () => {
+    it(`formats RETURNS clause`, async () => {
       testBigquery(dedent`
         CREATE FUNCTION IF NOT EXISTS my_func()
         RETURNS INT64
@@ -51,7 +51,7 @@ describe("function", () => {
       `);
     });
 
-    it(`formats OPTIONS (...)`, () => {
+    it(`formats OPTIONS (...)`, async () => {
       testBigquery(dedent`
         CREATE FUNCTION IF NOT EXISTS my_func()
         AS
@@ -60,7 +60,7 @@ describe("function", () => {
       `);
     });
 
-    it(`formats CREATE TABLE FUNCTION`, () => {
+    it(`formats CREATE TABLE FUNCTION`, async () => {
       testBigquery(dedent`
         CREATE TABLE FUNCTION my_func()
         RETURNS TABLE<id INT, name STRING>
@@ -69,7 +69,7 @@ describe("function", () => {
       `);
     });
 
-    it(`formats creation of remote function`, () => {
+    it(`formats creation of remote function`, async () => {
       testBigquery(dedent`
         CREATE FUNCTION my_func()
         RETURNS INT64
@@ -78,7 +78,7 @@ describe("function", () => {
       `);
     });
 
-    it(`formats JavaScript FUNCTION`, () => {
+    it(`formats JavaScript FUNCTION`, async () => {
       testBigquery(dedent`
         CREATE FUNCTION gen_random()
         RETURNS FLOAT64
@@ -90,7 +90,7 @@ describe("function", () => {
       `);
     });
 
-    it(`reformats JavaScript in JS function`, () => {
+    it(`reformats JavaScript in JS function`, async () => {
       expect(
         pretty(
           dedent`
@@ -113,7 +113,7 @@ describe("function", () => {
       `);
     });
 
-    it(`quotes JavaScript in double-quotes when single-quotes can't be used`, () => {
+    it(`quotes JavaScript in double-quotes when single-quotes can't be used`, async () => {
       expect(
         pretty(
           dedent`
@@ -134,7 +134,7 @@ describe("function", () => {
       `);
     });
 
-    it(`does not reformat JavaScript when neither ''' or """ can be easily used for quoting`, () => {
+    it(`does not reformat JavaScript when neither ''' or """ can be easily used for quoting`, async () => {
       expect(
         pretty(
           dedent`
@@ -155,13 +155,13 @@ describe("function", () => {
   });
 
   describe("drop function", () => {
-    it(`formats DROP FUNCTION`, () => {
+    it(`formats DROP FUNCTION`, async () => {
       testBigquery(`DROP FUNCTION my_schema.my_func`);
     });
-    it(`formats DROP TABLE FUNCTION`, () => {
+    it(`formats DROP TABLE FUNCTION`, async () => {
       testBigquery(`DROP TABLE FUNCTION my_func`);
     });
-    it(`formats IF EXISTS`, () => {
+    it(`formats IF EXISTS`, async () => {
       testBigquery(`DROP FUNCTION IF EXISTS my_func`);
     });
   });

--- a/test/ddl/index.test.ts
+++ b/test/ddl/index.test.ts
@@ -4,25 +4,25 @@ import { test, testBigquery } from "../test_utils";
 describe("index", () => {
   describe("create index", () => {
     it(`formats CREATE INDEX`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE INDEX my_index ON my_table (col1, col2)
       `);
     });
 
     it(`formats CREATE UNIQUE INDEX`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE UNIQUE INDEX my_index ON my_table (col)
       `);
     });
 
     it(`formats IF NOT EXISTS`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE INDEX IF NOT EXISTS my_index ON my_table (col)
       `);
     });
 
     it(`formats long columns list on multiple lines`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE UNIQUE INDEX IF NOT EXISTS my_index ON my_table (
           column_name_one,
           column_name_two,
@@ -32,14 +32,14 @@ describe("index", () => {
     });
 
     it(`formats WHERE clause on separate line`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE INDEX my_index ON my_table (col)
         WHERE col > 10
       `);
     });
 
     it(`formats BigQuery CREATE SEARCH INDEX with OPTIONS ()`, async () => {
-      test(
+      await test(
         dedent`
           CREATE SEARCH INDEX my_index ON my_table (col)
           OPTIONS (analyzer = 'LOG_ANALYZER')
@@ -49,7 +49,7 @@ describe("index", () => {
     });
 
     it(`formats BigQuery CREATE SEARCH INDEX with ALL COLUMNS`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         CREATE SEARCH INDEX my_index ON my_table (ALL COLUMNS)
       `);
     });
@@ -57,19 +57,19 @@ describe("index", () => {
 
   describe("drop index", () => {
     it(`formats DROP INDEX`, async () => {
-      test(dedent`
+      await test(dedent`
         DROP INDEX my_index
       `);
     });
 
     it(`formats IF EXISTS`, async () => {
-      test(dedent`
+      await test(dedent`
         DROP INDEX IF EXISTS my_index
       `);
     });
 
     it(`formats DROP SEARCH INDEX`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         DROP SEARCH INDEX my_index ON my_table
       `);
     });

--- a/test/ddl/index.test.ts
+++ b/test/ddl/index.test.ts
@@ -3,25 +3,25 @@ import { test, testBigquery } from "../test_utils";
 
 describe("index", () => {
   describe("create index", () => {
-    it(`formats CREATE INDEX`, () => {
+    it(`formats CREATE INDEX`, async () => {
       test(dedent`
         CREATE INDEX my_index ON my_table (col1, col2)
       `);
     });
 
-    it(`formats CREATE UNIQUE INDEX`, () => {
+    it(`formats CREATE UNIQUE INDEX`, async () => {
       test(dedent`
         CREATE UNIQUE INDEX my_index ON my_table (col)
       `);
     });
 
-    it(`formats IF NOT EXISTS`, () => {
+    it(`formats IF NOT EXISTS`, async () => {
       test(dedent`
         CREATE INDEX IF NOT EXISTS my_index ON my_table (col)
       `);
     });
 
-    it(`formats long columns list on multiple lines`, () => {
+    it(`formats long columns list on multiple lines`, async () => {
       test(dedent`
         CREATE UNIQUE INDEX IF NOT EXISTS my_index ON my_table (
           column_name_one,
@@ -31,14 +31,14 @@ describe("index", () => {
       `);
     });
 
-    it(`formats WHERE clause on separate line`, () => {
+    it(`formats WHERE clause on separate line`, async () => {
       test(dedent`
         CREATE INDEX my_index ON my_table (col)
         WHERE col > 10
       `);
     });
 
-    it(`formats BigQuery CREATE SEARCH INDEX with OPTIONS ()`, () => {
+    it(`formats BigQuery CREATE SEARCH INDEX with OPTIONS ()`, async () => {
       test(
         dedent`
           CREATE SEARCH INDEX my_index ON my_table (col)
@@ -48,7 +48,7 @@ describe("index", () => {
       );
     });
 
-    it(`formats BigQuery CREATE SEARCH INDEX with ALL COLUMNS`, () => {
+    it(`formats BigQuery CREATE SEARCH INDEX with ALL COLUMNS`, async () => {
       testBigquery(dedent`
         CREATE SEARCH INDEX my_index ON my_table (ALL COLUMNS)
       `);
@@ -56,19 +56,19 @@ describe("index", () => {
   });
 
   describe("drop index", () => {
-    it(`formats DROP INDEX`, () => {
+    it(`formats DROP INDEX`, async () => {
       test(dedent`
         DROP INDEX my_index
       `);
     });
 
-    it(`formats IF EXISTS`, () => {
+    it(`formats IF EXISTS`, async () => {
       test(dedent`
         DROP INDEX IF EXISTS my_index
       `);
     });
 
-    it(`formats DROP SEARCH INDEX`, () => {
+    it(`formats DROP SEARCH INDEX`, async () => {
       testBigquery(dedent`
         DROP SEARCH INDEX my_index ON my_table
       `);

--- a/test/ddl/procedure.test.ts
+++ b/test/ddl/procedure.test.ts
@@ -4,7 +4,7 @@ import { testBigquery } from "../test_utils";
 describe("procedure", () => {
   describe("create procedure", () => {
     it(`formats CREATE PROCEDURE`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE PROCEDURE drop_my_table(arg1 INT64, OUT arg2 STRING)
           BEGIN
@@ -15,7 +15,7 @@ describe("procedure", () => {
     });
 
     it(`formats OR REPLACE / IF NOT EXISTS`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE OR REPLACE PROCEDURE IF NOT EXISTS drop_my_table()
           BEGIN
@@ -26,7 +26,7 @@ describe("procedure", () => {
     });
 
     it(`formats long parameter list`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE PROCEDURE my_schema.my_long_procedure_name(
             IN first_parameter INT64,
@@ -41,7 +41,7 @@ describe("procedure", () => {
     });
 
     it(`formats OPTIONS (..)`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE PROCEDURE foo()
           OPTIONS (strict_mode = TRUE)
@@ -53,7 +53,7 @@ describe("procedure", () => {
     });
 
     it(`formats remote python procedure`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE PROCEDURE my_bq_project.my_dataset.spark_proc()
           WITH CONNECTION \`my-project-id.us.my-connection\`
@@ -64,7 +64,7 @@ describe("procedure", () => {
     });
 
     it(`formats inline python procedure`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE PROCEDURE spark_proc()
           WITH CONNECTION my_connection
@@ -83,11 +83,11 @@ describe("procedure", () => {
 
   describe("drop procedure", () => {
     it(`formats DROP PROCEDURE`, async () => {
-      testBigquery(`DROP PROCEDURE mydataset.myProcedure`);
+      await testBigquery(`DROP PROCEDURE mydataset.myProcedure`);
     });
 
     it(`formats IF EXISTS`, async () => {
-      testBigquery(`DROP PROCEDURE IF EXISTS foo`);
+      await testBigquery(`DROP PROCEDURE IF EXISTS foo`);
     });
   });
 });

--- a/test/ddl/procedure.test.ts
+++ b/test/ddl/procedure.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("procedure", () => {
   describe("create procedure", () => {
-    it(`formats CREATE PROCEDURE`, () => {
+    it(`formats CREATE PROCEDURE`, async () => {
       testBigquery(
         dedent`
           CREATE PROCEDURE drop_my_table(arg1 INT64, OUT arg2 STRING)
@@ -14,7 +14,7 @@ describe("procedure", () => {
       );
     });
 
-    it(`formats OR REPLACE / IF NOT EXISTS`, () => {
+    it(`formats OR REPLACE / IF NOT EXISTS`, async () => {
       testBigquery(
         dedent`
           CREATE OR REPLACE PROCEDURE IF NOT EXISTS drop_my_table()
@@ -25,7 +25,7 @@ describe("procedure", () => {
       );
     });
 
-    it(`formats long parameter list`, () => {
+    it(`formats long parameter list`, async () => {
       testBigquery(
         dedent`
           CREATE PROCEDURE my_schema.my_long_procedure_name(
@@ -40,7 +40,7 @@ describe("procedure", () => {
       );
     });
 
-    it(`formats OPTIONS (..)`, () => {
+    it(`formats OPTIONS (..)`, async () => {
       testBigquery(
         dedent`
           CREATE PROCEDURE foo()
@@ -52,7 +52,7 @@ describe("procedure", () => {
       );
     });
 
-    it(`formats remote python procedure`, () => {
+    it(`formats remote python procedure`, async () => {
       testBigquery(
         dedent`
           CREATE PROCEDURE my_bq_project.my_dataset.spark_proc()
@@ -63,7 +63,7 @@ describe("procedure", () => {
       );
     });
 
-    it(`formats inline python procedure`, () => {
+    it(`formats inline python procedure`, async () => {
       testBigquery(
         dedent`
           CREATE PROCEDURE spark_proc()
@@ -82,11 +82,11 @@ describe("procedure", () => {
   });
 
   describe("drop procedure", () => {
-    it(`formats DROP PROCEDURE`, () => {
+    it(`formats DROP PROCEDURE`, async () => {
       testBigquery(`DROP PROCEDURE mydataset.myProcedure`);
     });
 
-    it(`formats IF EXISTS`, () => {
+    it(`formats IF EXISTS`, async () => {
       testBigquery(`DROP PROCEDURE IF EXISTS foo`);
     });
   });

--- a/test/ddl/schema.test.ts
+++ b/test/ddl/schema.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("schema", () => {
   describe("create schema", () => {
-    it(`formats CREATE SCHEMA`, () => {
+    it(`formats CREATE SCHEMA`, async () => {
       testBigquery(
         dedent`
           CREATE SCHEMA schema_name
@@ -11,7 +11,7 @@ describe("schema", () => {
       );
     });
 
-    it(`formats IF NOT EXISTS`, () => {
+    it(`formats IF NOT EXISTS`, async () => {
       testBigquery(
         dedent`
           CREATE SCHEMA IF NOT EXISTS schema_name
@@ -19,7 +19,7 @@ describe("schema", () => {
       );
     });
 
-    it(`formats OPTIONS (..)`, () => {
+    it(`formats OPTIONS (..)`, async () => {
       testBigquery(
         dedent`
           CREATE SCHEMA schema_name
@@ -28,7 +28,7 @@ describe("schema", () => {
       );
     });
 
-    it(`formats DEFAULT COLLATE`, () => {
+    it(`formats DEFAULT COLLATE`, async () => {
       testBigquery(
         dedent`
           CREATE SCHEMA schema_name
@@ -39,7 +39,7 @@ describe("schema", () => {
   });
 
   describe("drop schema", () => {
-    it(`formats DROP SCHEMA`, () => {
+    it(`formats DROP SCHEMA`, async () => {
       testBigquery(
         dedent`
           DROP SCHEMA schema_name
@@ -47,7 +47,7 @@ describe("schema", () => {
       );
     });
 
-    it(`formats IF EXISTS`, () => {
+    it(`formats IF EXISTS`, async () => {
       testBigquery(
         dedent`
           DROP SCHEMA IF EXISTS schema_name
@@ -55,7 +55,7 @@ describe("schema", () => {
       );
     });
 
-    it(`formats CASCADE/RESTRICT`, () => {
+    it(`formats CASCADE/RESTRICT`, async () => {
       testBigquery(
         dedent`
           DROP SCHEMA schema_name CASCADE
@@ -65,7 +65,7 @@ describe("schema", () => {
   });
 
   describe("alter schema", () => {
-    it(`formats ALTER SCHEMA .. SET OPTIONS`, () => {
+    it(`formats ALTER SCHEMA .. SET OPTIONS`, async () => {
       testBigquery(
         dedent`
           ALTER SCHEMA IF EXISTS my_schema
@@ -74,7 +74,7 @@ describe("schema", () => {
       );
     });
 
-    it(`formats ALTER SCHEMA .. SET DEFAULT COLLATE`, () => {
+    it(`formats ALTER SCHEMA .. SET DEFAULT COLLATE`, async () => {
       testBigquery(
         dedent`
           ALTER SCHEMA my_schema

--- a/test/ddl/schema.test.ts
+++ b/test/ddl/schema.test.ts
@@ -4,7 +4,7 @@ import { testBigquery } from "../test_utils";
 describe("schema", () => {
   describe("create schema", () => {
     it(`formats CREATE SCHEMA`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE SCHEMA schema_name
         `
@@ -12,7 +12,7 @@ describe("schema", () => {
     });
 
     it(`formats IF NOT EXISTS`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE SCHEMA IF NOT EXISTS schema_name
         `
@@ -20,7 +20,7 @@ describe("schema", () => {
     });
 
     it(`formats OPTIONS (..)`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE SCHEMA schema_name
           OPTIONS (friendly_name = 'Happy schema')
@@ -29,7 +29,7 @@ describe("schema", () => {
     });
 
     it(`formats DEFAULT COLLATE`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE SCHEMA schema_name
           DEFAULT COLLATE 'und:ci'
@@ -40,7 +40,7 @@ describe("schema", () => {
 
   describe("drop schema", () => {
     it(`formats DROP SCHEMA`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           DROP SCHEMA schema_name
         `
@@ -48,7 +48,7 @@ describe("schema", () => {
     });
 
     it(`formats IF EXISTS`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           DROP SCHEMA IF EXISTS schema_name
         `
@@ -56,7 +56,7 @@ describe("schema", () => {
     });
 
     it(`formats CASCADE/RESTRICT`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           DROP SCHEMA schema_name CASCADE
         `
@@ -66,7 +66,7 @@ describe("schema", () => {
 
   describe("alter schema", () => {
     it(`formats ALTER SCHEMA .. SET OPTIONS`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           ALTER SCHEMA IF EXISTS my_schema
           SET OPTIONS (description = 'blah')
@@ -75,7 +75,7 @@ describe("schema", () => {
     });
 
     it(`formats ALTER SCHEMA .. SET DEFAULT COLLATE`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           ALTER SCHEMA my_schema
           SET DEFAULT COLLATE 'und:ci'

--- a/test/ddl/trigger.test.ts
+++ b/test/ddl/trigger.test.ts
@@ -3,7 +3,7 @@ import { test } from "../test_utils";
 
 describe("trigger", () => {
   describe("create trigger", () => {
-    it(`formats CREATE TRIGGER .. INSTEAD OF UPDATE OF`, () => {
+    it(`formats CREATE TRIGGER .. INSTEAD OF UPDATE OF`, async () => {
       test(dedent`
         CREATE TRIGGER cust_addr_chng
         INSTEAD OF UPDATE OF cust_addr ON customer_address
@@ -15,7 +15,7 @@ describe("trigger", () => {
       `);
     });
 
-    it(`formats long UPDATE OF column list`, () => {
+    it(`formats long UPDATE OF column list`, async () => {
       test(dedent`
         CREATE TRIGGER cust_addr_chng
         INSTEAD OF UPDATE OF
@@ -29,7 +29,7 @@ describe("trigger", () => {
       `);
     });
 
-    it(`formats TEMPORARY TRIGGER IF NOT EXISTS`, () => {
+    it(`formats TEMPORARY TRIGGER IF NOT EXISTS`, async () => {
       test(dedent`
         CREATE TEMPORARY TRIGGER IF NOT EXISTS cust_addr_del
         DELETE ON customer_address
@@ -39,7 +39,7 @@ describe("trigger", () => {
       `);
     });
 
-    it(`formats FOR EACH ROW`, () => {
+    it(`formats FOR EACH ROW`, async () => {
       test(dedent`
         CREATE TRIGGER cust_addr_del
         INSERT ON customer_address
@@ -51,7 +51,7 @@ describe("trigger", () => {
       `);
     });
 
-    it(`formats WHEN condition`, () => {
+    it(`formats WHEN condition`, async () => {
       test(dedent`
         CREATE TRIGGER cust_addr_del
         INSERT ON customer_address
@@ -63,7 +63,7 @@ describe("trigger", () => {
       `);
     });
 
-    it(`formats long WHEN condition`, () => {
+    it(`formats long WHEN condition`, async () => {
       test(dedent`
         CREATE TRIGGER cust_addr_del
         INSERT ON customer_address
@@ -79,11 +79,11 @@ describe("trigger", () => {
   });
 
   describe("drop trigger", () => {
-    it(`formats DROP TRIGGER`, () => {
+    it(`formats DROP TRIGGER`, async () => {
       test(`DROP TRIGGER my_trigger`);
     });
 
-    it(`formats IF EXISTS`, () => {
+    it(`formats IF EXISTS`, async () => {
       test(`DROP TRIGGER IF EXISTS my_trigger`);
     });
   });

--- a/test/ddl/trigger.test.ts
+++ b/test/ddl/trigger.test.ts
@@ -4,7 +4,7 @@ import { test } from "../test_utils";
 describe("trigger", () => {
   describe("create trigger", () => {
     it(`formats CREATE TRIGGER .. INSTEAD OF UPDATE OF`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE TRIGGER cust_addr_chng
         INSTEAD OF UPDATE OF cust_addr ON customer_address
         BEGIN
@@ -16,7 +16,7 @@ describe("trigger", () => {
     });
 
     it(`formats long UPDATE OF column list`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE TRIGGER cust_addr_chng
         INSTEAD OF UPDATE OF
           cust_address,
@@ -30,7 +30,7 @@ describe("trigger", () => {
     });
 
     it(`formats TEMPORARY TRIGGER IF NOT EXISTS`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE TEMPORARY TRIGGER IF NOT EXISTS cust_addr_del
         DELETE ON customer_address
         BEGIN
@@ -40,7 +40,7 @@ describe("trigger", () => {
     });
 
     it(`formats FOR EACH ROW`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE TRIGGER cust_addr_del
         INSERT ON customer_address
         FOR EACH ROW
@@ -52,7 +52,7 @@ describe("trigger", () => {
     });
 
     it(`formats WHEN condition`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE TRIGGER cust_addr_del
         INSERT ON customer_address
         FOR EACH ROW
@@ -64,7 +64,7 @@ describe("trigger", () => {
     });
 
     it(`formats long WHEN condition`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE TRIGGER cust_addr_del
         INSERT ON customer_address
         WHEN
@@ -80,11 +80,11 @@ describe("trigger", () => {
 
   describe("drop trigger", () => {
     it(`formats DROP TRIGGER`, async () => {
-      test(`DROP TRIGGER my_trigger`);
+      await test(`DROP TRIGGER my_trigger`);
     });
 
     it(`formats IF EXISTS`, async () => {
-      test(`DROP TRIGGER IF EXISTS my_trigger`);
+      await test(`DROP TRIGGER IF EXISTS my_trigger`);
     });
   });
 });

--- a/test/ddl/view.test.ts
+++ b/test/ddl/view.test.ts
@@ -3,21 +3,21 @@ import { test, testBigquery } from "../test_utils";
 
 describe("view", () => {
   describe("create view", () => {
-    it(`formats CREATE VIEW`, () => {
+    it(`formats CREATE VIEW`, async () => {
       test(dedent`
         CREATE VIEW active_client_id AS
           SELECT id FROM client WHERE active = TRUE
       `);
     });
 
-    it(`formats CREATE TEMPORARY VIEW IF NOT EXISTS`, () => {
+    it(`formats CREATE TEMPORARY VIEW IF NOT EXISTS`, async () => {
       test(dedent`
         CREATE TEMPORARY VIEW IF NOT EXISTS active_client_id AS
           SELECT 1
       `);
     });
 
-    it(`formats CREATE OR REPLACE VIEW`, () => {
+    it(`formats CREATE OR REPLACE VIEW`, async () => {
       testBigquery(
         dedent`
           CREATE OR REPLACE VIEW active_client_id AS
@@ -26,14 +26,14 @@ describe("view", () => {
       );
     });
 
-    it(`formats CREATE VIEW with column list`, () => {
+    it(`formats CREATE VIEW with column list`, async () => {
       test(dedent`
         CREATE VIEW foobar (col1, col2, col3) AS
           SELECT 1
       `);
     });
 
-    it(`formats CREATE VIEW with long column list`, () => {
+    it(`formats CREATE VIEW with long column list`, async () => {
       test(dedent`
         CREATE VIEW active_client_in_queue (
           client_name,
@@ -45,7 +45,7 @@ describe("view", () => {
       `);
     });
 
-    it(`formats CREATE VIEW with BigQuery options`, () => {
+    it(`formats CREATE VIEW with BigQuery options`, async () => {
       testBigquery(
         dedent`
           CREATE VIEW foo
@@ -56,7 +56,7 @@ describe("view", () => {
       );
     });
 
-    it(`formats simple CREATE MATERIALIZED VIEW`, () => {
+    it(`formats simple CREATE MATERIALIZED VIEW`, async () => {
       testBigquery(
         dedent`
           CREATE MATERIALIZED VIEW foo AS
@@ -65,7 +65,7 @@ describe("view", () => {
       );
     });
 
-    it(`formats CREATE MATERIALIZED VIEW with extra clauses`, () => {
+    it(`formats CREATE MATERIALIZED VIEW with extra clauses`, async () => {
       testBigquery(
         dedent`
           CREATE MATERIALIZED VIEW foo
@@ -79,21 +79,21 @@ describe("view", () => {
   });
 
   describe("drop view", () => {
-    it(`formats DROP VIEW`, () => {
+    it(`formats DROP VIEW`, async () => {
       test(`DROP VIEW active_client_view`);
     });
 
-    it(`formats DROP VIEW IF EXISTS`, () => {
+    it(`formats DROP VIEW IF EXISTS`, async () => {
       test(`DROP VIEW IF EXISTS my_schema.active_client_view`);
     });
 
-    it(`formats DROP MATERIALIZED VIEW`, () => {
+    it(`formats DROP MATERIALIZED VIEW`, async () => {
       testBigquery(`DROP MATERIALIZED VIEW foo`);
     });
   });
 
   describe("alter view", () => {
-    it(`formats ALTER VIEW .. SET OPTIONS`, () => {
+    it(`formats ALTER VIEW .. SET OPTIONS`, async () => {
       testBigquery(
         dedent`
           ALTER VIEW IF EXISTS my_view
@@ -102,7 +102,7 @@ describe("view", () => {
       );
     });
 
-    it(`formats ALTER MATERIALIZED VIEW .. SET OPTIONS`, () => {
+    it(`formats ALTER MATERIALIZED VIEW .. SET OPTIONS`, async () => {
       testBigquery(
         dedent`
           ALTER MATERIALIZED VIEW my_view

--- a/test/ddl/view.test.ts
+++ b/test/ddl/view.test.ts
@@ -4,21 +4,21 @@ import { test, testBigquery } from "../test_utils";
 describe("view", () => {
   describe("create view", () => {
     it(`formats CREATE VIEW`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE VIEW active_client_id AS
           SELECT id FROM client WHERE active = TRUE
       `);
     });
 
     it(`formats CREATE TEMPORARY VIEW IF NOT EXISTS`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE TEMPORARY VIEW IF NOT EXISTS active_client_id AS
           SELECT 1
       `);
     });
 
     it(`formats CREATE OR REPLACE VIEW`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE OR REPLACE VIEW active_client_id AS
             SELECT 1
@@ -27,14 +27,14 @@ describe("view", () => {
     });
 
     it(`formats CREATE VIEW with column list`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE VIEW foobar (col1, col2, col3) AS
           SELECT 1
       `);
     });
 
     it(`formats CREATE VIEW with long column list`, async () => {
-      test(dedent`
+      await test(dedent`
         CREATE VIEW active_client_in_queue (
           client_name,
           client_org_name,
@@ -46,7 +46,7 @@ describe("view", () => {
     });
 
     it(`formats CREATE VIEW with BigQuery options`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE VIEW foo
           OPTIONS (friendly_name = "newview")
@@ -57,7 +57,7 @@ describe("view", () => {
     });
 
     it(`formats simple CREATE MATERIALIZED VIEW`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE MATERIALIZED VIEW foo AS
             SELECT 1
@@ -66,7 +66,7 @@ describe("view", () => {
     });
 
     it(`formats CREATE MATERIALIZED VIEW with extra clauses`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           CREATE MATERIALIZED VIEW foo
           PARTITION BY DATE(col_datetime)
@@ -80,21 +80,21 @@ describe("view", () => {
 
   describe("drop view", () => {
     it(`formats DROP VIEW`, async () => {
-      test(`DROP VIEW active_client_view`);
+      await test(`DROP VIEW active_client_view`);
     });
 
     it(`formats DROP VIEW IF EXISTS`, async () => {
-      test(`DROP VIEW IF EXISTS my_schema.active_client_view`);
+      await test(`DROP VIEW IF EXISTS my_schema.active_client_view`);
     });
 
     it(`formats DROP MATERIALIZED VIEW`, async () => {
-      testBigquery(`DROP MATERIALIZED VIEW foo`);
+      await testBigquery(`DROP MATERIALIZED VIEW foo`);
     });
   });
 
   describe("alter view", () => {
     it(`formats ALTER VIEW .. SET OPTIONS`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           ALTER VIEW IF EXISTS my_view
           SET OPTIONS (description = 'blah')
@@ -103,7 +103,7 @@ describe("view", () => {
     });
 
     it(`formats ALTER MATERIALIZED VIEW .. SET OPTIONS`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           ALTER MATERIALIZED VIEW my_view
           SET OPTIONS (description = 'blah')

--- a/test/dml/delete.test.ts
+++ b/test/dml/delete.test.ts
@@ -2,21 +2,21 @@ import dedent from "dedent-js";
 import { test, testBigquery } from "../test_utils";
 
 describe("delete", () => {
-  it(`formats DELETE statement`, () => {
+  it(`formats DELETE statement`, async () => {
     test(dedent`
       DELETE FROM employee
       WHERE id = 10
     `);
   });
 
-  it(`formats DELETE without FROM`, () => {
+  it(`formats DELETE without FROM`, async () => {
     testBigquery(dedent`
       DELETE employee
       WHERE id = 10
     `);
   });
 
-  it(`formats DELETE statement with RETURNING clause`, () => {
+  it(`formats DELETE statement with RETURNING clause`, async () => {
     test(dedent`
       DELETE FROM employee
       WHERE id = 10
@@ -27,7 +27,7 @@ describe("delete", () => {
     `);
   });
 
-  it(`formats DELETE statement with ORDER BY and LIMIT`, () => {
+  it(`formats DELETE statement with ORDER BY and LIMIT`, async () => {
     test(dedent`
       DELETE FROM employee
       WHERE id = 10

--- a/test/dml/delete.test.ts
+++ b/test/dml/delete.test.ts
@@ -3,21 +3,21 @@ import { test, testBigquery } from "../test_utils";
 
 describe("delete", () => {
   it(`formats DELETE statement`, async () => {
-    test(dedent`
+    await test(dedent`
       DELETE FROM employee
       WHERE id = 10
     `);
   });
 
   it(`formats DELETE without FROM`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       DELETE employee
       WHERE id = 10
     `);
   });
 
   it(`formats DELETE statement with RETURNING clause`, async () => {
-    test(dedent`
+    await test(dedent`
       DELETE FROM employee
       WHERE id = 10
       RETURNING
@@ -28,7 +28,7 @@ describe("delete", () => {
   });
 
   it(`formats DELETE statement with ORDER BY and LIMIT`, async () => {
-    test(dedent`
+    await test(dedent`
       DELETE FROM employee
       WHERE id = 10
       ORDER BY name

--- a/test/dml/insert.test.ts
+++ b/test/dml/insert.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { test, testBigquery } from "../test_utils";
 
 describe("insert", () => {
-  it(`formats INSERT statement without column names`, () => {
+  it(`formats INSERT statement without column names`, async () => {
     test(dedent`
       INSERT INTO client
       VALUES
@@ -10,7 +10,7 @@ describe("insert", () => {
     `);
   });
 
-  it(`formats INSERT statement without INTO`, () => {
+  it(`formats INSERT statement without INTO`, async () => {
     testBigquery(dedent`
       INSERT client
       VALUES
@@ -18,7 +18,7 @@ describe("insert", () => {
     `);
   });
 
-  it(`formats INSERT statement with column names`, () => {
+  it(`formats INSERT statement with column names`, async () => {
     test(dedent`
       INSERT INTO client
         (id, fname, lname, org_id)
@@ -27,7 +27,7 @@ describe("insert", () => {
     `);
   });
 
-  it(`formats INSERT statement with multiple rows always to multiple lines`, () => {
+  it(`formats INSERT statement with multiple rows always to multiple lines`, async () => {
     test(dedent`
       INSERT INTO client
       VALUES
@@ -36,7 +36,7 @@ describe("insert", () => {
     `);
   });
 
-  it(`formats INSERT statement with long column names list`, () => {
+  it(`formats INSERT statement with long column names list`, async () => {
     test(dedent`
       INSERT INTO client
         (id, first_name, last_name, organization_id, project_access_enabled)
@@ -47,7 +47,7 @@ describe("insert", () => {
     `);
   });
 
-  it(`formats INSERT statement with very long column names and values lists`, () => {
+  it(`formats INSERT statement with very long column names and values lists`, async () => {
     test(dedent`
       INSERT INTO client
         (
@@ -71,7 +71,7 @@ describe("insert", () => {
     `);
   });
 
-  it(`formats OR ABORT modifier`, () => {
+  it(`formats OR ABORT modifier`, async () => {
     test(dedent`
       INSERT OR ABORT INTO employee
       VALUES
@@ -79,14 +79,14 @@ describe("insert", () => {
     `);
   });
 
-  it("formats insertion of DEFAULT VALUES", () => {
+  it("formats insertion of DEFAULT VALUES", async () => {
     test(dedent`
       INSERT INTO employee
       DEFAULT VALUES
     `);
   });
 
-  it("formats DEFAULT values among normal values", () => {
+  it("formats DEFAULT values among normal values", async () => {
     testBigquery(dedent`
       INSERT INTO employee
       VALUES
@@ -94,14 +94,14 @@ describe("insert", () => {
     `);
   });
 
-  it("formats insertion of query", () => {
+  it("formats insertion of query", async () => {
     test(dedent`
       INSERT INTO employee
       SELECT * FROM tbl
     `);
   });
 
-  it("formats upsert clauses", () => {
+  it("formats upsert clauses", async () => {
     test(dedent`
       INSERT INTO client
       VALUES
@@ -114,7 +114,7 @@ describe("insert", () => {
     `);
   });
 
-  it(`formats INSERT with RETURNING clause`, () => {
+  it(`formats INSERT with RETURNING clause`, async () => {
     test(dedent`
       INSERT INTO client
       VALUES

--- a/test/dml/insert.test.ts
+++ b/test/dml/insert.test.ts
@@ -3,7 +3,7 @@ import { test, testBigquery } from "../test_utils";
 
 describe("insert", () => {
   it(`formats INSERT statement without column names`, async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO client
       VALUES
         (1, 'John', 'Doe', 27)
@@ -11,7 +11,7 @@ describe("insert", () => {
   });
 
   it(`formats INSERT statement without INTO`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       INSERT client
       VALUES
         (1, 2, 3)
@@ -19,7 +19,7 @@ describe("insert", () => {
   });
 
   it(`formats INSERT statement with column names`, async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO client
         (id, fname, lname, org_id)
       VALUES
@@ -28,7 +28,7 @@ describe("insert", () => {
   });
 
   it(`formats INSERT statement with multiple rows always to multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO client
       VALUES
         (1, 'John', 'Doe', 27),
@@ -37,7 +37,7 @@ describe("insert", () => {
   });
 
   it(`formats INSERT statement with long column names list`, async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO client
         (id, first_name, last_name, organization_id, project_access_enabled)
       VALUES
@@ -48,7 +48,7 @@ describe("insert", () => {
   });
 
   it(`formats INSERT statement with very long column names and values lists`, async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO client
         (
           id,
@@ -72,7 +72,7 @@ describe("insert", () => {
   });
 
   it(`formats OR ABORT modifier`, async () => {
-    test(dedent`
+    await test(dedent`
       INSERT OR ABORT INTO employee
       VALUES
         (1, 2, 3)
@@ -80,14 +80,14 @@ describe("insert", () => {
   });
 
   it("formats insertion of DEFAULT VALUES", async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO employee
       DEFAULT VALUES
     `);
   });
 
   it("formats DEFAULT values among normal values", async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       INSERT INTO employee
       VALUES
         (1, 2, DEFAULT, 3)
@@ -95,14 +95,14 @@ describe("insert", () => {
   });
 
   it("formats insertion of query", async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO employee
       SELECT * FROM tbl
     `);
   });
 
   it("formats upsert clauses", async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO client
       VALUES
         (1, 2, 3)
@@ -115,7 +115,7 @@ describe("insert", () => {
   });
 
   it(`formats INSERT with RETURNING clause`, async () => {
-    test(dedent`
+    await test(dedent`
       INSERT INTO client
       VALUES
         (1, 2, 3)

--- a/test/dml/merge.test.ts
+++ b/test/dml/merge.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("merge", () => {
-  it(`formats MERGE .. DELETE`, () => {
+  it(`formats MERGE .. DELETE`, async () => {
     testBigquery(
       dedent`
         MERGE INTO dataset.DetailedInventory AS target
@@ -14,7 +14,7 @@ describe("merge", () => {
     );
   });
 
-  it(`formats MERGE .. INSERT (cols) VALUES`, () => {
+  it(`formats MERGE .. INSERT (cols) VALUES`, async () => {
     testBigquery(
       dedent`
         MERGE INTO target
@@ -29,7 +29,7 @@ describe("merge", () => {
     );
   });
 
-  it(`formats MERGE .. INSERT VALUES`, () => {
+  it(`formats MERGE .. INSERT VALUES`, async () => {
     testBigquery(
       dedent`
         MERGE INTO target
@@ -43,7 +43,7 @@ describe("merge", () => {
     );
   });
 
-  it(`formats MERGE .. INSERT ROW`, () => {
+  it(`formats MERGE .. INSERT ROW`, async () => {
     testBigquery(
       dedent`
         MERGE INTO target
@@ -55,7 +55,7 @@ describe("merge", () => {
     );
   });
 
-  it(`formats MERGE .. INSERT (columns) ROW`, () => {
+  it(`formats MERGE .. INSERT (columns) ROW`, async () => {
     testBigquery(
       dedent`
         MERGE INTO target
@@ -69,7 +69,7 @@ describe("merge", () => {
     );
   });
 
-  it(`formats MERGE .. UPDATE`, () => {
+  it(`formats MERGE .. UPDATE`, async () => {
     testBigquery(
       dedent`
         MERGE INTO target
@@ -84,7 +84,7 @@ describe("merge", () => {
     );
   });
 
-  it(`formats MERGE .. UPDATE with single-element update`, () => {
+  it(`formats MERGE .. UPDATE with single-element update`, async () => {
     testBigquery(
       dedent`
         MERGE INTO target
@@ -96,7 +96,7 @@ describe("merge", () => {
     );
   });
 
-  it(`formats long ON-condition`, () => {
+  it(`formats long ON-condition`, async () => {
     testBigquery(
       dedent`
         MERGE INTO target
@@ -111,7 +111,7 @@ describe("merge", () => {
     );
   });
 
-  it(`formats long WHEN-condition`, () => {
+  it(`formats long WHEN-condition`, async () => {
     testBigquery(
       dedent`
         MERGE INTO target

--- a/test/dml/merge.test.ts
+++ b/test/dml/merge.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("merge", () => {
   it(`formats MERGE .. DELETE`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO dataset.DetailedInventory AS target
         USING dataset.Inventory AS source
@@ -15,7 +15,7 @@ describe("merge", () => {
   });
 
   it(`formats MERGE .. INSERT (cols) VALUES`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO target
         USING source
@@ -30,7 +30,7 @@ describe("merge", () => {
   });
 
   it(`formats MERGE .. INSERT VALUES`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO target
         USING source
@@ -44,7 +44,7 @@ describe("merge", () => {
   });
 
   it(`formats MERGE .. INSERT ROW`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO target
         USING source
@@ -56,7 +56,7 @@ describe("merge", () => {
   });
 
   it(`formats MERGE .. INSERT (columns) ROW`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO target
         USING source
@@ -70,7 +70,7 @@ describe("merge", () => {
   });
 
   it(`formats MERGE .. UPDATE`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO target
         USING source
@@ -85,7 +85,7 @@ describe("merge", () => {
   });
 
   it(`formats MERGE .. UPDATE with single-element update`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO target
         USING source
@@ -97,7 +97,7 @@ describe("merge", () => {
   });
 
   it(`formats long ON-condition`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO target
         USING source
@@ -112,7 +112,7 @@ describe("merge", () => {
   });
 
   it(`formats long WHEN-condition`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         MERGE INTO target
         USING source

--- a/test/dml/truncate.test.ts
+++ b/test/dml/truncate.test.ts
@@ -1,7 +1,7 @@
 import { testBigquery } from "../test_utils";
 
 describe("truncate", () => {
-  it(`formats TRUNCATE TABLE statement`, () => {
+  it(`formats TRUNCATE TABLE statement`, async () => {
     testBigquery(`TRUNCATE TABLE dataset.employee`);
   });
 });

--- a/test/dml/truncate.test.ts
+++ b/test/dml/truncate.test.ts
@@ -2,6 +2,6 @@ import { testBigquery } from "../test_utils";
 
 describe("truncate", () => {
   it(`formats TRUNCATE TABLE statement`, async () => {
-    testBigquery(`TRUNCATE TABLE dataset.employee`);
+    await testBigquery(`TRUNCATE TABLE dataset.employee`);
   });
 });

--- a/test/dml/update.test.ts
+++ b/test/dml/update.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { test } from "../test_utils";
 
 describe("update", () => {
-  it(`formats UPDATE statement`, () => {
+  it(`formats UPDATE statement`, async () => {
     test(dedent`
       UPDATE employee
       SET salary = 1000
@@ -10,7 +10,7 @@ describe("update", () => {
     `);
   });
 
-  it(`formats UPDATE statement with multiple assignments`, () => {
+  it(`formats UPDATE statement with multiple assignments`, async () => {
     test(dedent`
       UPDATE employee
       SET
@@ -21,7 +21,7 @@ describe("update", () => {
     `);
   });
 
-  it(`formats UPDATE with parenthesized column groups`, () => {
+  it(`formats UPDATE with parenthesized column groups`, async () => {
     test(dedent`
       UPDATE employee
       SET
@@ -30,14 +30,14 @@ describe("update", () => {
     `);
   });
 
-  it(`formats OR ABORT modifier`, () => {
+  it(`formats OR ABORT modifier`, async () => {
     test(dedent`
       UPDATE OR ABORT employee
       SET salary = 1000
     `);
   });
 
-  it(`formats UPDATE with RETURNING clause`, () => {
+  it(`formats UPDATE with RETURNING clause`, async () => {
     test(dedent`
       UPDATE client
       SET status = 2

--- a/test/dml/update.test.ts
+++ b/test/dml/update.test.ts
@@ -3,7 +3,7 @@ import { test } from "../test_utils";
 
 describe("update", () => {
   it(`formats UPDATE statement`, async () => {
-    test(dedent`
+    await test(dedent`
       UPDATE employee
       SET salary = 1000
       WHERE id = 10
@@ -11,7 +11,7 @@ describe("update", () => {
   });
 
   it(`formats UPDATE statement with multiple assignments`, async () => {
-    test(dedent`
+    await test(dedent`
       UPDATE employee
       SET
         name = 'John Doe',
@@ -22,7 +22,7 @@ describe("update", () => {
   });
 
   it(`formats UPDATE with parenthesized column groups`, async () => {
-    test(dedent`
+    await test(dedent`
       UPDATE employee
       SET
         (name, salary) = ('John Doe', 1000),
@@ -31,14 +31,14 @@ describe("update", () => {
   });
 
   it(`formats OR ABORT modifier`, async () => {
-    test(dedent`
+    await test(dedent`
       UPDATE OR ABORT employee
       SET salary = 1000
     `);
   });
 
   it(`formats UPDATE with RETURNING clause`, async () => {
-    test(dedent`
+    await test(dedent`
       UPDATE client
       SET status = 2
       RETURNING *

--- a/test/explain.test.ts
+++ b/test/explain.test.ts
@@ -2,15 +2,15 @@ import dedent from "dedent-js";
 import { test } from "./test_utils";
 
 describe("explain", () => {
-  it(`formats EXPLAIN statement`, () => {
+  it(`formats EXPLAIN statement`, async () => {
     test(`EXPLAIN SELECT 1`);
   });
 
-  it(`formats EXPLAIN QUERY PLAIN statement`, () => {
+  it(`formats EXPLAIN QUERY PLAIN statement`, async () => {
     test(`EXPLAIN QUERY PLAN SELECT 1`);
   });
 
-  it(`formats long EXPLAIN statement to multiple lines`, () => {
+  it(`formats long EXPLAIN statement to multiple lines`, async () => {
     test(dedent`
       EXPLAIN
         SELECT id, name, item_count
@@ -19,7 +19,7 @@ describe("explain", () => {
     `);
   });
 
-  it(`formats long EXPLAIN QUERY PLAN statement to multiple lines`, () => {
+  it(`formats long EXPLAIN QUERY PLAN statement to multiple lines`, async () => {
     test(dedent`
       EXPLAIN QUERY PLAN
         SELECT id, name, item_count

--- a/test/explain.test.ts
+++ b/test/explain.test.ts
@@ -3,15 +3,15 @@ import { test } from "./test_utils";
 
 describe("explain", () => {
   it(`formats EXPLAIN statement`, async () => {
-    test(`EXPLAIN SELECT 1`);
+    await test(`EXPLAIN SELECT 1`);
   });
 
   it(`formats EXPLAIN QUERY PLAIN statement`, async () => {
-    test(`EXPLAIN QUERY PLAN SELECT 1`);
+    await test(`EXPLAIN QUERY PLAN SELECT 1`);
   });
 
   it(`formats long EXPLAIN statement to multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       EXPLAIN
         SELECT id, name, item_count
         FROM inventory
@@ -20,7 +20,7 @@ describe("explain", () => {
   });
 
   it(`formats long EXPLAIN QUERY PLAN statement to multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       EXPLAIN QUERY PLAN
         SELECT id, name, item_count
         FROM inventory

--- a/test/expr/expr.test.ts
+++ b/test/expr/expr.test.ts
@@ -4,7 +4,7 @@ import { pretty, test, testBigquery } from "../test_utils";
 describe("expr", () => {
   it(`formats binary expressions`, async () => {
     expect(
-      pretty(`SELECT 1 + 2 / 3 * (5 - 1), TRUE OR FALSE AND TRUE`, {
+      await pretty(`SELECT 1 + 2 / 3 * (5 - 1), TRUE OR FALSE AND TRUE`, {
         printWidth: 25,
       })
     ).toBe(dedent`
@@ -15,15 +15,15 @@ describe("expr", () => {
   });
 
   it(`formats IN expressions`, async () => {
-    test(`SELECT col1 IN (1, 2, 3), col2 NOT IN (4, 5, 6)`);
+    await test(`SELECT col1 IN (1, 2, 3), col2 NOT IN (4, 5, 6)`);
   });
 
   it(`formats LIKE expressions`, async () => {
-    test(`SELECT fname LIKE 'Mar%', lname NOT LIKE '%ony'`);
+    await test(`SELECT fname LIKE 'Mar%', lname NOT LIKE '%ony'`);
   });
 
   it(`formats IS expressions`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT
         x IS NOT NULL,
         y IS NULL,
@@ -33,7 +33,7 @@ describe("expr", () => {
   });
 
   it(`formats BETWEEN expressions`, async () => {
-    test(
+    await test(
       dedent`
         SELECT
           x BETWEEN 1 AND 10,
@@ -44,7 +44,7 @@ describe("expr", () => {
   });
 
   it(`formats EXISTS expressions`, async () => {
-    test(
+    await test(
       dedent`
         SELECT
           EXISTS (SELECT * FROM tbl),
@@ -55,19 +55,19 @@ describe("expr", () => {
   });
 
   it(`formats ISNULL / NOTNULL / NOT NULL expressions`, async () => {
-    test(`SELECT fname ISNULL, xname NOTNULL, lname NOT NULL`);
+    await test(`SELECT fname ISNULL, xname NOTNULL, lname NOT NULL`);
   });
 
   it(`formats NOT expressions`, async () => {
-    test(`SELECT NOT x > 10`);
+    await test(`SELECT NOT x > 10`);
   });
 
   it(`formats negation`, async () => {
-    test(`SELECT -x`);
+    await test(`SELECT -x`);
   });
 
   it(`formats a chain of AND/OR operators to multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM client
       WHERE
@@ -80,32 +80,32 @@ describe("expr", () => {
   });
 
   it(`eliminates unnecessary (((nested))) parenthesis`, async () => {
-    expect(pretty(`SELECT (((1 + 2))) * 3`)).toBe(dedent`
+    expect(await pretty(`SELECT (((1 + 2))) * 3`)).toBe(dedent`
       SELECT (1 + 2) * 3
     `);
   });
 
   it(`preserves comments when eliminating (((nested))) parenthesis`, async () => {
-    expect(pretty(`SELECT (/*c1*/(/*c2*/(/*c3*/ 1 + 2))) * 3`)).toBe(dedent`
+    expect(await pretty(`SELECT (/*c1*/(/*c2*/(/*c3*/ 1 + 2))) * 3`)).toBe(dedent`
       SELECT /*c1*/ /*c2*/ (/*c3*/ 1 + 2) * 3
     `);
   });
 
   it(`eliminates unnecessary parenthesis around function arguments`, async () => {
-    expect(pretty(`SELECT my_func((id), (name))`)).toBe(dedent`
+    expect(await pretty(`SELECT my_func((id), (name))`)).toBe(dedent`
       SELECT my_func(id, name)
     `);
   });
 
   it(`preserves comments when eliminating func(((arg))) parenthesis`, async () => {
-    expect(pretty(`SELECT count(/*c1*/(/*c2*/ id))`)).toBe(dedent`
+    expect(await pretty(`SELECT count(/*c1*/(/*c2*/ id))`)).toBe(dedent`
       SELECT count(/*c1*/ /*c2*/ id)
     `);
   });
 
   describe("case", () => {
     it(`formats CASE expression always on multiple lines`, async () => {
-      test(dedent`
+      await test(dedent`
         SELECT
           CASE x
             WHEN 1 THEN 'A'
@@ -115,7 +115,7 @@ describe("expr", () => {
     });
 
     it(`formats CASE expression with base expression`, async () => {
-      test(dedent`
+      await test(dedent`
         SELECT
           CASE status
             WHEN 1 THEN 'good'
@@ -126,7 +126,7 @@ describe("expr", () => {
     });
 
     it(`formats CASE expression without base expression`, async () => {
-      test(dedent`
+      await test(dedent`
         SELECT
           CASE
             WHEN status = 1 THEN 'good'
@@ -139,11 +139,11 @@ describe("expr", () => {
 
   describe("BigQuery", () => {
     it(`formats BigQuery quoted table names`, async () => {
-      testBigquery("SELECT * FROM `my-project.mydataset.mytable`");
+      await testBigquery("SELECT * FROM `my-project.mydataset.mytable`");
     });
 
     it(`formats BigQuery array field access`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT
           item_array,
           item_array[OFFSET(1)] AS item_offset,
@@ -154,7 +154,7 @@ describe("expr", () => {
     });
 
     it(`formats BigQuery array field access to multiple lines`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT
           ["Coffee Cup", "Tea Kettle", "Milk Glass"][
             SAFE_OFFSET(some_really_long_index_number)
@@ -163,13 +163,13 @@ describe("expr", () => {
     });
 
     it(`formats BigQuery JSON field access`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT json_value.class.students[0]['name']
       `);
     });
 
     it(`formats BigQuery @@system_variables`, async () => {
-      testBigquery(`SELECT @@error.message`);
+      await testBigquery(`SELECT @@error.message`);
     });
   });
 });

--- a/test/expr/expr.test.ts
+++ b/test/expr/expr.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { pretty, test, testBigquery } from "../test_utils";
 
 describe("expr", () => {
-  it(`formats binary expressions`, () => {
+  it(`formats binary expressions`, async () => {
     expect(
       pretty(`SELECT 1 + 2 / 3 * (5 - 1), TRUE OR FALSE AND TRUE`, {
         printWidth: 25,
@@ -14,15 +14,15 @@ describe("expr", () => {
     `);
   });
 
-  it(`formats IN expressions`, () => {
+  it(`formats IN expressions`, async () => {
     test(`SELECT col1 IN (1, 2, 3), col2 NOT IN (4, 5, 6)`);
   });
 
-  it(`formats LIKE expressions`, () => {
+  it(`formats LIKE expressions`, async () => {
     test(`SELECT fname LIKE 'Mar%', lname NOT LIKE '%ony'`);
   });
 
-  it(`formats IS expressions`, () => {
+  it(`formats IS expressions`, async () => {
     test(dedent`
       SELECT
         x IS NOT NULL,
@@ -32,7 +32,7 @@ describe("expr", () => {
     `);
   });
 
-  it(`formats BETWEEN expressions`, () => {
+  it(`formats BETWEEN expressions`, async () => {
     test(
       dedent`
         SELECT
@@ -43,7 +43,7 @@ describe("expr", () => {
     );
   });
 
-  it(`formats EXISTS expressions`, () => {
+  it(`formats EXISTS expressions`, async () => {
     test(
       dedent`
         SELECT
@@ -54,19 +54,19 @@ describe("expr", () => {
     );
   });
 
-  it(`formats ISNULL / NOTNULL / NOT NULL expressions`, () => {
+  it(`formats ISNULL / NOTNULL / NOT NULL expressions`, async () => {
     test(`SELECT fname ISNULL, xname NOTNULL, lname NOT NULL`);
   });
 
-  it(`formats NOT expressions`, () => {
+  it(`formats NOT expressions`, async () => {
     test(`SELECT NOT x > 10`);
   });
 
-  it(`formats negation`, () => {
+  it(`formats negation`, async () => {
     test(`SELECT -x`);
   });
 
-  it(`formats a chain of AND/OR operators to multiple lines`, () => {
+  it(`formats a chain of AND/OR operators to multiple lines`, async () => {
     test(dedent`
       SELECT *
       FROM client
@@ -79,32 +79,32 @@ describe("expr", () => {
     `);
   });
 
-  it(`eliminates unnecessary (((nested))) parenthesis`, () => {
+  it(`eliminates unnecessary (((nested))) parenthesis`, async () => {
     expect(pretty(`SELECT (((1 + 2))) * 3`)).toBe(dedent`
       SELECT (1 + 2) * 3
     `);
   });
 
-  it(`preserves comments when eliminating (((nested))) parenthesis`, () => {
+  it(`preserves comments when eliminating (((nested))) parenthesis`, async () => {
     expect(pretty(`SELECT (/*c1*/(/*c2*/(/*c3*/ 1 + 2))) * 3`)).toBe(dedent`
       SELECT /*c1*/ /*c2*/ (/*c3*/ 1 + 2) * 3
     `);
   });
 
-  it(`eliminates unnecessary parenthesis around function arguments`, () => {
+  it(`eliminates unnecessary parenthesis around function arguments`, async () => {
     expect(pretty(`SELECT my_func((id), (name))`)).toBe(dedent`
       SELECT my_func(id, name)
     `);
   });
 
-  it(`preserves comments when eliminating func(((arg))) parenthesis`, () => {
+  it(`preserves comments when eliminating func(((arg))) parenthesis`, async () => {
     expect(pretty(`SELECT count(/*c1*/(/*c2*/ id))`)).toBe(dedent`
       SELECT count(/*c1*/ /*c2*/ id)
     `);
   });
 
   describe("case", () => {
-    it(`formats CASE expression always on multiple lines`, () => {
+    it(`formats CASE expression always on multiple lines`, async () => {
       test(dedent`
         SELECT
           CASE x
@@ -114,7 +114,7 @@ describe("expr", () => {
       `);
     });
 
-    it(`formats CASE expression with base expression`, () => {
+    it(`formats CASE expression with base expression`, async () => {
       test(dedent`
         SELECT
           CASE status
@@ -125,7 +125,7 @@ describe("expr", () => {
       `);
     });
 
-    it(`formats CASE expression without base expression`, () => {
+    it(`formats CASE expression without base expression`, async () => {
       test(dedent`
         SELECT
           CASE
@@ -138,11 +138,11 @@ describe("expr", () => {
   });
 
   describe("BigQuery", () => {
-    it(`formats BigQuery quoted table names`, () => {
+    it(`formats BigQuery quoted table names`, async () => {
       testBigquery("SELECT * FROM `my-project.mydataset.mytable`");
     });
 
-    it(`formats BigQuery array field access`, () => {
+    it(`formats BigQuery array field access`, async () => {
       testBigquery(dedent`
         SELECT
           item_array,
@@ -153,7 +153,7 @@ describe("expr", () => {
       `);
     });
 
-    it(`formats BigQuery array field access to multiple lines`, () => {
+    it(`formats BigQuery array field access to multiple lines`, async () => {
       testBigquery(dedent`
         SELECT
           ["Coffee Cup", "Tea Kettle", "Milk Glass"][
@@ -162,13 +162,13 @@ describe("expr", () => {
       `);
     });
 
-    it(`formats BigQuery JSON field access`, () => {
+    it(`formats BigQuery JSON field access`, async () => {
       testBigquery(dedent`
         SELECT json_value.class.students[0]['name']
       `);
     });
 
-    it(`formats BigQuery @@system_variables`, () => {
+    it(`formats BigQuery @@system_variables`, async () => {
       testBigquery(`SELECT @@error.message`);
     });
   });

--- a/test/expr/func.test.ts
+++ b/test/expr/func.test.ts
@@ -4,14 +4,14 @@ import { pretty, test, testBigquery } from "../test_utils";
 // Functions and function-like language constructs
 describe("functions", () => {
   it(`formats function call to single line`, async () => {
-    expect(pretty(`SELECT sqrt(1, 2, 3)`, { printWidth: 16 })).toBe(dedent`
+    expect(await pretty(`SELECT sqrt(1, 2, 3)`, { printWidth: 16 })).toBe(dedent`
       SELECT
         sqrt(1, 2, 3)
     `);
   });
 
   it(`formats function call to multiple lines`, async () => {
-    expect(pretty(`SELECT sqrt(1, 2, 3)`, { printWidth: 10 })).toBe(dedent`
+    expect(await pretty(`SELECT sqrt(1, 2, 3)`, { printWidth: 10 })).toBe(dedent`
       SELECT
         sqrt(
           1,
@@ -22,21 +22,21 @@ describe("functions", () => {
   });
 
   it(`formats count(*) func call`, async () => {
-    test(`SELECT count(*)`);
+    await test(`SELECT count(*)`);
   });
 
   it(`formats count(DISTINCT) func call`, async () => {
-    test(`SELECT count(DISTINCT id)`);
+    await test(`SELECT count(DISTINCT id)`);
   });
 
   describe("cast", () => {
     it(`formats CAST expression`, async () => {
-      test(`SELECT CAST(127 AS INT)`);
+      await test(`SELECT CAST(127 AS INT)`);
     });
 
     it(`formats CAST() with FORMAT`, async () => {
-      testBigquery(`SELECT CAST('11-08' AS DATE FORMAT 'DD-MM')`);
-      testBigquery(
+      await testBigquery(`SELECT CAST('11-08' AS DATE FORMAT 'DD-MM')`);
+      await testBigquery(
         `SELECT CAST('12:35' AS TIME FORMAT 'HH:MI' AT TIME ZONE 'UTC')`
       );
     });
@@ -44,22 +44,22 @@ describe("functions", () => {
 
   describe("raise", () => {
     it(`formats RAISE expression`, async () => {
-      test(`SELECT RAISE(IGNORE), RAISE(ABORT, 'Oh no!')`);
+      await test(`SELECT RAISE(IGNORE), RAISE(ABORT, 'Oh no!')`);
     });
   });
 
   describe("extract", () => {
     it(`formats EXTRACT() expression`, async () => {
-      testBigquery(`SELECT EXTRACT(MONTH FROM DATE '2002-08-16')`);
-      testBigquery(`SELECT EXTRACT(WEEK(SUNDAY) FROM date)`);
+      await testBigquery(`SELECT EXTRACT(MONTH FROM DATE '2002-08-16')`);
+      await testBigquery(`SELECT EXTRACT(WEEK(SUNDAY) FROM date)`);
     });
   });
 
   describe("any_value", () => {
     it(`formats ANY_VALUE() with HAVING`, async () => {
-      testBigquery(`SELECT any_value(fruit)`);
-      testBigquery(`SELECT any_value(fruit HAVING MAX sold)`);
-      testBigquery(`SELECT any_value(fruit HAVING MIN sold)`);
+      await testBigquery(`SELECT any_value(fruit)`);
+      await testBigquery(`SELECT any_value(fruit HAVING MAX sold)`);
+      await testBigquery(`SELECT any_value(fruit HAVING MIN sold)`);
     });
   });
 });

--- a/test/expr/func.test.ts
+++ b/test/expr/func.test.ts
@@ -3,14 +3,14 @@ import { pretty, test, testBigquery } from "../test_utils";
 
 // Functions and function-like language constructs
 describe("functions", () => {
-  it(`formats function call to single line`, () => {
+  it(`formats function call to single line`, async () => {
     expect(pretty(`SELECT sqrt(1, 2, 3)`, { printWidth: 16 })).toBe(dedent`
       SELECT
         sqrt(1, 2, 3)
     `);
   });
 
-  it(`formats function call to multiple lines`, () => {
+  it(`formats function call to multiple lines`, async () => {
     expect(pretty(`SELECT sqrt(1, 2, 3)`, { printWidth: 10 })).toBe(dedent`
       SELECT
         sqrt(
@@ -21,20 +21,20 @@ describe("functions", () => {
     `);
   });
 
-  it(`formats count(*) func call`, () => {
+  it(`formats count(*) func call`, async () => {
     test(`SELECT count(*)`);
   });
 
-  it(`formats count(DISTINCT) func call`, () => {
+  it(`formats count(DISTINCT) func call`, async () => {
     test(`SELECT count(DISTINCT id)`);
   });
 
   describe("cast", () => {
-    it(`formats CAST expression`, () => {
+    it(`formats CAST expression`, async () => {
       test(`SELECT CAST(127 AS INT)`);
     });
 
-    it(`formats CAST() with FORMAT`, () => {
+    it(`formats CAST() with FORMAT`, async () => {
       testBigquery(`SELECT CAST('11-08' AS DATE FORMAT 'DD-MM')`);
       testBigquery(
         `SELECT CAST('12:35' AS TIME FORMAT 'HH:MI' AT TIME ZONE 'UTC')`
@@ -43,20 +43,20 @@ describe("functions", () => {
   });
 
   describe("raise", () => {
-    it(`formats RAISE expression`, () => {
+    it(`formats RAISE expression`, async () => {
       test(`SELECT RAISE(IGNORE), RAISE(ABORT, 'Oh no!')`);
     });
   });
 
   describe("extract", () => {
-    it(`formats EXTRACT() expression`, () => {
+    it(`formats EXTRACT() expression`, async () => {
       testBigquery(`SELECT EXTRACT(MONTH FROM DATE '2002-08-16')`);
       testBigquery(`SELECT EXTRACT(WEEK(SUNDAY) FROM date)`);
     });
   });
 
   describe("any_value", () => {
-    it(`formats ANY_VALUE() with HAVING`, () => {
+    it(`formats ANY_VALUE() with HAVING`, async () => {
       testBigquery(`SELECT any_value(fruit)`);
       testBigquery(`SELECT any_value(fruit HAVING MAX sold)`);
       testBigquery(`SELECT any_value(fruit HAVING MIN sold)`);

--- a/test/expr/json.test.ts
+++ b/test/expr/json.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { pretty, testBigquery } from "../test_utils";
 
 describe("json", () => {
-  it(`formats JSON literals`, () => {
+  it(`formats JSON literals`, async () => {
     testBigquery(
       dedent`
         SELECT JSON '{ "foo": true }'
@@ -10,7 +10,7 @@ describe("json", () => {
     );
   });
 
-  it(`formats JSON literal using Prettier JSON formatter`, () => {
+  it(`formats JSON literal using Prettier JSON formatter`, async () => {
     expect(
       pretty(`SELECT JSON '{"fname":"John","lname":"Doe","valid":true}'`, {
         dialect: "bigquery",
@@ -22,7 +22,7 @@ describe("json", () => {
     );
   });
 
-  it(`formats long JSON literal using Prettier JSON formatter to multiple lines`, () => {
+  it(`formats long JSON literal using Prettier JSON formatter to multiple lines`, async () => {
     expect(
       pretty(
         `SELECT JSON '{"firstName":"John","lastName":"Doe","inventory":["Pickaxe", "Compass", "Dirt"]}'`,
@@ -42,7 +42,7 @@ describe("json", () => {
     );
   });
 
-  it(`converts double-quoted JSON literal to single-quoted one`, () => {
+  it(`converts double-quoted JSON literal to single-quoted one`, async () => {
     expect(
       pretty(String.raw`SELECT JSON "{\"name\":\"John Doe\"}"`, {
         dialect: "bigquery",
@@ -54,7 +54,7 @@ describe("json", () => {
     );
   });
 
-  it(`converts triple-quoted JSON literal to single-quoted one when it fits to single line`, () => {
+  it(`converts triple-quoted JSON literal to single-quoted one when it fits to single line`, async () => {
     expect(
       pretty(`SELECT JSON '''{"name":"John Doe"}'''`, {
         dialect: "bigquery",
@@ -66,7 +66,7 @@ describe("json", () => {
     );
   });
 
-  it(`converts triple-dbl-quoted JSON literal to triple-single-quoted`, () => {
+  it(`converts triple-dbl-quoted JSON literal to triple-single-quoted`, async () => {
     expect(
       pretty(
         `SELECT JSON """{"firstName":"John","lastName":"Doe","inventory":["Pickaxe", "Compass", "Dirt"]}"""`,
@@ -86,7 +86,7 @@ describe("json", () => {
     );
   });
 
-  it(`always uses triple-quotes when JSON contains single quote character`, () => {
+  it(`always uses triple-quotes when JSON contains single quote character`, async () => {
     expect(
       pretty(String.raw`SELECT JSON '{"name":"It\'s Mr John"}'`, {
         dialect: "bigquery",
@@ -99,7 +99,7 @@ describe("json", () => {
   });
 
   // Just skip formatting in this tricky case for now
-  it(`doesn't format JSON when it contains triple quotes`, () => {
+  it(`doesn't format JSON when it contains triple quotes`, async () => {
     expect(
       pretty(String.raw`SELECT JSON '{"name":"It\'\'\'s Mr John"}'`, {
         dialect: "bigquery",
@@ -112,12 +112,12 @@ describe("json", () => {
   });
 
   // Also skip dealing with escapes for now
-  it(`doesn't format JSON when it contains escape sequences`, () => {
+  it(`doesn't format JSON when it contains escape sequences`, async () => {
     testBigquery(String.raw`SELECT JSON '{ "name": "\\n" }'`);
   });
 
   // Also skip dealing with raw strings
-  it(`doesn't format JSON inside raw strings`, () => {
+  it(`doesn't format JSON inside raw strings`, async () => {
     testBigquery(`SELECT JSON r'{"name":"John"}'`);
   });
 });

--- a/test/expr/json.test.ts
+++ b/test/expr/json.test.ts
@@ -3,7 +3,7 @@ import { pretty, testBigquery } from "../test_utils";
 
 describe("json", () => {
   it(`formats JSON literals`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         SELECT JSON '{ "foo": true }'
       `
@@ -12,7 +12,7 @@ describe("json", () => {
 
   it(`formats JSON literal using Prettier JSON formatter`, async () => {
     expect(
-      pretty(`SELECT JSON '{"fname":"John","lname":"Doe","valid":true}'`, {
+      await pretty(`SELECT JSON '{"fname":"John","lname":"Doe","valid":true}'`, {
         dialect: "bigquery",
       })
     ).toBe(
@@ -24,7 +24,7 @@ describe("json", () => {
 
   it(`formats long JSON literal using Prettier JSON formatter to multiple lines`, async () => {
     expect(
-      pretty(
+      await pretty(
         `SELECT JSON '{"firstName":"John","lastName":"Doe","inventory":["Pickaxe", "Compass", "Dirt"]}'`,
         { dialect: "bigquery" }
       )
@@ -44,7 +44,7 @@ describe("json", () => {
 
   it(`converts double-quoted JSON literal to single-quoted one`, async () => {
     expect(
-      pretty(String.raw`SELECT JSON "{\"name\":\"John Doe\"}"`, {
+      await pretty(String.raw`SELECT JSON "{\"name\":\"John Doe\"}"`, {
         dialect: "bigquery",
       })
     ).toBe(
@@ -56,7 +56,7 @@ describe("json", () => {
 
   it(`converts triple-quoted JSON literal to single-quoted one when it fits to single line`, async () => {
     expect(
-      pretty(`SELECT JSON '''{"name":"John Doe"}'''`, {
+      await pretty(`SELECT JSON '''{"name":"John Doe"}'''`, {
         dialect: "bigquery",
       })
     ).toBe(
@@ -68,7 +68,7 @@ describe("json", () => {
 
   it(`converts triple-dbl-quoted JSON literal to triple-single-quoted`, async () => {
     expect(
-      pretty(
+      await pretty(
         `SELECT JSON """{"firstName":"John","lastName":"Doe","inventory":["Pickaxe", "Compass", "Dirt"]}"""`,
         { dialect: "bigquery" }
       )
@@ -88,7 +88,7 @@ describe("json", () => {
 
   it(`always uses triple-quotes when JSON contains single quote character`, async () => {
     expect(
-      pretty(String.raw`SELECT JSON '{"name":"It\'s Mr John"}'`, {
+      await pretty(String.raw`SELECT JSON '{"name":"It\'s Mr John"}'`, {
         dialect: "bigquery",
       })
     ).toBe(
@@ -101,7 +101,7 @@ describe("json", () => {
   // Just skip formatting in this tricky case for now
   it(`doesn't format JSON when it contains triple quotes`, async () => {
     expect(
-      pretty(String.raw`SELECT JSON '{"name":"It\'\'\'s Mr John"}'`, {
+      await pretty(String.raw`SELECT JSON '{"name":"It\'\'\'s Mr John"}'`, {
         dialect: "bigquery",
       })
     ).toBe(
@@ -113,11 +113,11 @@ describe("json", () => {
 
   // Also skip dealing with escapes for now
   it(`doesn't format JSON when it contains escape sequences`, async () => {
-    testBigquery(String.raw`SELECT JSON '{ "name": "\\n" }'`);
+    await testBigquery(String.raw`SELECT JSON '{ "name": "\\n" }'`);
   });
 
   // Also skip dealing with raw strings
   it(`doesn't format JSON inside raw strings`, async () => {
-    testBigquery(`SELECT JSON r'{"name":"John"}'`);
+    await testBigquery(`SELECT JSON r'{"name":"John"}'`);
   });
 });

--- a/test/expr/literal.test.ts
+++ b/test/expr/literal.test.ts
@@ -3,11 +3,11 @@ import { test, testBigquery } from "../test_utils";
 
 describe("literal", () => {
   it(`formats BigQuery NUMERIC and BIGNUMERIC literals`, async () => {
-    testBigquery(`SELECT NUMERIC '12345', BIGNUMERIC '1.23456e05'`);
+    await testBigquery(`SELECT NUMERIC '12345', BIGNUMERIC '1.23456e05'`);
   });
 
   it(`formats DATE/TIME literals`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         SELECT
           DATE '2014-09-27',
@@ -19,7 +19,7 @@ describe("literal", () => {
   });
 
   it(`formats INTERVAL literals`, async () => {
-    testBigquery(
+    await testBigquery(
       dedent`
         SELECT
           INTERVAL 5 DAY,
@@ -32,7 +32,7 @@ describe("literal", () => {
 
   describe("array literals", () => {
     it(`formats array literals`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           SELECT
             [1, 2, 3],
@@ -44,7 +44,7 @@ describe("literal", () => {
     });
 
     it(`formats long array literal to multiple lines`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           SELECT
             [
@@ -60,7 +60,7 @@ describe("literal", () => {
 
   describe("struct literals", () => {
     it(`formats struct literals`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           SELECT
             (1, 2, 3),
@@ -73,7 +73,7 @@ describe("literal", () => {
     });
 
     it(`formats long struct literal to multiple lines`, async () => {
-      testBigquery(
+      await testBigquery(
         dedent`
           SELECT
             STRUCT(

--- a/test/expr/literal.test.ts
+++ b/test/expr/literal.test.ts
@@ -2,11 +2,11 @@ import dedent from "dedent-js";
 import { test, testBigquery } from "../test_utils";
 
 describe("literal", () => {
-  it(`formats BigQuery NUMERIC and BIGNUMERIC literals`, () => {
+  it(`formats BigQuery NUMERIC and BIGNUMERIC literals`, async () => {
     testBigquery(`SELECT NUMERIC '12345', BIGNUMERIC '1.23456e05'`);
   });
 
-  it(`formats DATE/TIME literals`, () => {
+  it(`formats DATE/TIME literals`, async () => {
     testBigquery(
       dedent`
         SELECT
@@ -18,7 +18,7 @@ describe("literal", () => {
     );
   });
 
-  it(`formats INTERVAL literals`, () => {
+  it(`formats INTERVAL literals`, async () => {
     testBigquery(
       dedent`
         SELECT
@@ -31,7 +31,7 @@ describe("literal", () => {
   });
 
   describe("array literals", () => {
-    it(`formats array literals`, () => {
+    it(`formats array literals`, async () => {
       testBigquery(
         dedent`
           SELECT
@@ -43,7 +43,7 @@ describe("literal", () => {
       );
     });
 
-    it(`formats long array literal to multiple lines`, () => {
+    it(`formats long array literal to multiple lines`, async () => {
       testBigquery(
         dedent`
           SELECT
@@ -59,7 +59,7 @@ describe("literal", () => {
   });
 
   describe("struct literals", () => {
-    it(`formats struct literals`, () => {
+    it(`formats struct literals`, async () => {
       testBigquery(
         dedent`
           SELECT
@@ -72,7 +72,7 @@ describe("literal", () => {
       );
     });
 
-    it(`formats long struct literal to multiple lines`, () => {
+    it(`formats long struct literal to multiple lines`, async () => {
       testBigquery(
         dedent`
           SELECT

--- a/test/options/keywordCase.test.ts
+++ b/test/options/keywordCase.test.ts
@@ -2,13 +2,13 @@ import dedent from "dedent-js";
 import { pretty } from "../test_utils";
 
 describe("sqlKeywordCase option", () => {
-  it(`defaults to uppercasing of all keywords`, () => {
+  it(`defaults to uppercasing of all keywords`, async () => {
     expect(pretty(`select * From tbl WHERE x > 0`)).toBe(dedent`
       SELECT * FROM tbl WHERE x > 0
     `);
   });
 
-  it(`sqlKeywordCase: "preserve" keeps keywords case as-is`, () => {
+  it(`sqlKeywordCase: "preserve" keeps keywords case as-is`, async () => {
     expect(
       pretty(`select * From tbl WHERE x > 0`, {
         sqlKeywordCase: "preserve",
@@ -18,7 +18,7 @@ describe("sqlKeywordCase option", () => {
     `);
   });
 
-  it(`sqlKeywordCase: "upper" converts keywords to uppercase`, () => {
+  it(`sqlKeywordCase: "upper" converts keywords to uppercase`, async () => {
     expect(
       pretty(`select * From tbl WHERE x > 0`, {
         sqlKeywordCase: "upper",
@@ -28,7 +28,7 @@ describe("sqlKeywordCase option", () => {
     `);
   });
 
-  it(`sqlKeywordCase: "lower" converts keywords to lowercase`, () => {
+  it(`sqlKeywordCase: "lower" converts keywords to lowercase`, async () => {
     expect(
       pretty(`select * From tbl WHERE x > 0`, {
         sqlKeywordCase: "lower",

--- a/test/options/keywordCase.test.ts
+++ b/test/options/keywordCase.test.ts
@@ -3,14 +3,14 @@ import { pretty } from "../test_utils";
 
 describe("sqlKeywordCase option", () => {
   it(`defaults to uppercasing of all keywords`, async () => {
-    expect(pretty(`select * From tbl WHERE x > 0`)).toBe(dedent`
+    expect(await pretty(`select * From tbl WHERE x > 0`)).toBe(dedent`
       SELECT * FROM tbl WHERE x > 0
     `);
   });
 
   it(`sqlKeywordCase: "preserve" keeps keywords case as-is`, async () => {
     expect(
-      pretty(`select * From tbl WHERE x > 0`, {
+      await pretty(`select * From tbl WHERE x > 0`, {
         sqlKeywordCase: "preserve",
       })
     ).toBe(dedent`
@@ -20,7 +20,7 @@ describe("sqlKeywordCase option", () => {
 
   it(`sqlKeywordCase: "upper" converts keywords to uppercase`, async () => {
     expect(
-      pretty(`select * From tbl WHERE x > 0`, {
+      await pretty(`select * From tbl WHERE x > 0`, {
         sqlKeywordCase: "upper",
       })
     ).toBe(dedent`
@@ -30,7 +30,7 @@ describe("sqlKeywordCase option", () => {
 
   it(`sqlKeywordCase: "lower" converts keywords to lowercase`, async () => {
     expect(
-      pretty(`select * From tbl WHERE x > 0`, {
+      await pretty(`select * From tbl WHERE x > 0`, {
         sqlKeywordCase: "lower",
       })
     ).toBe(dedent`

--- a/test/options/paramTypes.test.ts
+++ b/test/options/paramTypes.test.ts
@@ -2,29 +2,29 @@ import { pretty, test } from "../test_utils";
 
 describe("sqlParamTypes option", () => {
   it(`by default bound parameters are not supported`, async () => {
-    expect(() => pretty(`SELECT * FROM tbl WHERE x = ?`)).toThrowError();
+    await expect(pretty(`SELECT * FROM tbl WHERE x = ?`)).rejects.toThrowError();
   });
 
   it(`positional parameters: ?`, async () => {
-    test(`SELECT * FROM tbl WHERE x = ? AND y = ?`, {
+    await test(`SELECT * FROM tbl WHERE x = ? AND y = ?`, {
       sqlParamTypes: ["?"],
     });
   });
 
   it(`indexed parameters: ?nr`, async () => {
-    test(`SELECT * FROM tbl WHERE x = ?1 AND y = ?2`, {
+    await test(`SELECT * FROM tbl WHERE x = ?1 AND y = ?2`, {
       sqlParamTypes: ["?nr"],
     });
   });
 
   it(`named parameters: :name`, async () => {
-    test(`SELECT * FROM tbl WHERE x = :foo AND y = :bar`, {
+    await test(`SELECT * FROM tbl WHERE x = :foo AND y = :bar`, {
       sqlParamTypes: [":name"],
     });
   });
 
   it(`mix of different parameter types`, async () => {
-    test(`SELECT * FROM tbl WHERE x = @foo AND y = $bar`, {
+    await test(`SELECT * FROM tbl WHERE x = @foo AND y = $bar`, {
       sqlParamTypes: ["@name", "$name"],
     });
   });

--- a/test/options/paramTypes.test.ts
+++ b/test/options/paramTypes.test.ts
@@ -1,29 +1,29 @@
 import { pretty, test } from "../test_utils";
 
 describe("sqlParamTypes option", () => {
-  it(`by default bound parameters are not supported`, () => {
+  it(`by default bound parameters are not supported`, async () => {
     expect(() => pretty(`SELECT * FROM tbl WHERE x = ?`)).toThrowError();
   });
 
-  it(`positional parameters: ?`, () => {
+  it(`positional parameters: ?`, async () => {
     test(`SELECT * FROM tbl WHERE x = ? AND y = ?`, {
       sqlParamTypes: ["?"],
     });
   });
 
-  it(`indexed parameters: ?nr`, () => {
+  it(`indexed parameters: ?nr`, async () => {
     test(`SELECT * FROM tbl WHERE x = ?1 AND y = ?2`, {
       sqlParamTypes: ["?nr"],
     });
   });
 
-  it(`named parameters: :name`, () => {
+  it(`named parameters: :name`, async () => {
     test(`SELECT * FROM tbl WHERE x = :foo AND y = :bar`, {
       sqlParamTypes: [":name"],
     });
   });
 
-  it(`mix of different parameter types`, () => {
+  it(`mix of different parameter types`, async () => {
     test(`SELECT * FROM tbl WHERE x = @foo AND y = $bar`, {
       sqlParamTypes: ["@name", "$name"],
     });

--- a/test/proc/block.test.ts
+++ b/test/proc/block.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("block statement", () => {
   it(`formats BEGIN .. END`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       BEGIN
         SELECT 1;
         SELECT 2;
@@ -13,7 +13,7 @@ describe("block statement", () => {
   });
 
   it(`formats BEGIN .. EXCEPTION .. END`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       BEGIN
         SELECT 1;
       EXCEPTION WHEN ERROR THEN

--- a/test/proc/block.test.ts
+++ b/test/proc/block.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("block statement", () => {
-  it(`formats BEGIN .. END`, () => {
+  it(`formats BEGIN .. END`, async () => {
     testBigquery(dedent`
       BEGIN
         SELECT 1;
@@ -12,7 +12,7 @@ describe("block statement", () => {
     `);
   });
 
-  it(`formats BEGIN .. EXCEPTION .. END`, () => {
+  it(`formats BEGIN .. EXCEPTION .. END`, async () => {
     testBigquery(dedent`
       BEGIN
         SELECT 1;

--- a/test/proc/call.test.ts
+++ b/test/proc/call.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("call", () => {
   it(`formats CALL statement`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CALL proc_name(arg1, arg2, arg3)
     `);
   });

--- a/test/proc/call.test.ts
+++ b/test/proc/call.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("call", () => {
-  it(`formats CALL statement`, () => {
+  it(`formats CALL statement`, async () => {
     testBigquery(dedent`
       CALL proc_name(arg1, arg2, arg3)
     `);

--- a/test/proc/case.test.ts
+++ b/test/proc/case.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("case", () => {
-  it(`formats procedural CASE`, () => {
+  it(`formats procedural CASE`, async () => {
     testBigquery(dedent`
       CASE foo
         WHEN 1 THEN

--- a/test/proc/case.test.ts
+++ b/test/proc/case.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("case", () => {
   it(`formats procedural CASE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       CASE foo
         WHEN 1 THEN
           SELECT CONCAT('Product one');

--- a/test/proc/declare.test.ts
+++ b/test/proc/declare.test.ts
@@ -2,25 +2,25 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("declare", () => {
-  it(`formats basic DECLARE statement`, () => {
+  it(`formats basic DECLARE statement`, async () => {
     testBigquery(dedent`
       DECLARE x
     `);
   });
 
-  it(`formats DECLARE with type`, () => {
+  it(`formats DECLARE with type`, async () => {
     testBigquery(dedent`
       DECLARE x INT64
     `);
   });
 
-  it(`formats declaring of multiple variables`, () => {
+  it(`formats declaring of multiple variables`, async () => {
     testBigquery(dedent`
       DECLARE foo, bar, baz INT64
     `);
   });
 
-  it(`formats DEFAULT`, () => {
+  it(`formats DEFAULT`, async () => {
     testBigquery(dedent`
       DECLARE d DATE DEFAULT CURRENT_DATE()
     `);

--- a/test/proc/declare.test.ts
+++ b/test/proc/declare.test.ts
@@ -3,25 +3,25 @@ import { testBigquery } from "../test_utils";
 
 describe("declare", () => {
   it(`formats basic DECLARE statement`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       DECLARE x
     `);
   });
 
   it(`formats DECLARE with type`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       DECLARE x INT64
     `);
   });
 
   it(`formats declaring of multiple variables`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       DECLARE foo, bar, baz INT64
     `);
   });
 
   it(`formats DEFAULT`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       DECLARE d DATE DEFAULT CURRENT_DATE()
     `);
   });

--- a/test/proc/if.test.ts
+++ b/test/proc/if.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("if", () => {
   it(`formats IF .. THEN .. END IF`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       IF x > 10 THEN
         SELECT 1;
       END IF
@@ -11,7 +11,7 @@ describe("if", () => {
   });
 
   it(`formats ELSE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       IF x > 10 THEN
         SELECT 1;
       ELSE
@@ -21,7 +21,7 @@ describe("if", () => {
   });
 
   it(`formats ELSEIF`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       IF x > 10 THEN
         SELECT 1;
       ELSEIF x > 1 THEN
@@ -35,7 +35,7 @@ describe("if", () => {
   });
 
   it(`formats IF with multiple statements inside`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       IF x > 10 THEN
         SELECT 1;
         SELECT 2;
@@ -45,7 +45,7 @@ describe("if", () => {
   });
 
   it(`formats IF with long condition`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       IF
         EXISTS (SELECT 1 FROM schema.products WHERE product_id = target_product_id)
         AND target_product_id IS NOT NULL
@@ -56,7 +56,7 @@ describe("if", () => {
   });
 
   it(`formats ELSEIF with long condition`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       IF TRUE THEN
         SELECT 1;
       ELSEIF

--- a/test/proc/if.test.ts
+++ b/test/proc/if.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("if", () => {
-  it(`formats IF .. THEN .. END IF`, () => {
+  it(`formats IF .. THEN .. END IF`, async () => {
     testBigquery(dedent`
       IF x > 10 THEN
         SELECT 1;
@@ -10,7 +10,7 @@ describe("if", () => {
     `);
   });
 
-  it(`formats ELSE`, () => {
+  it(`formats ELSE`, async () => {
     testBigquery(dedent`
       IF x > 10 THEN
         SELECT 1;
@@ -20,7 +20,7 @@ describe("if", () => {
     `);
   });
 
-  it(`formats ELSEIF`, () => {
+  it(`formats ELSEIF`, async () => {
     testBigquery(dedent`
       IF x > 10 THEN
         SELECT 1;
@@ -34,7 +34,7 @@ describe("if", () => {
     `);
   });
 
-  it(`formats IF with multiple statements inside`, () => {
+  it(`formats IF with multiple statements inside`, async () => {
     testBigquery(dedent`
       IF x > 10 THEN
         SELECT 1;
@@ -44,7 +44,7 @@ describe("if", () => {
     `);
   });
 
-  it(`formats IF with long condition`, () => {
+  it(`formats IF with long condition`, async () => {
     testBigquery(dedent`
       IF
         EXISTS (SELECT 1 FROM schema.products WHERE product_id = target_product_id)
@@ -55,7 +55,7 @@ describe("if", () => {
     `);
   });
 
-  it(`formats ELSEIF with long condition`, () => {
+  it(`formats ELSEIF with long condition`, async () => {
     testBigquery(dedent`
       IF TRUE THEN
         SELECT 1;

--- a/test/proc/loops.test.ts
+++ b/test/proc/loops.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("loops", () => {
   it(`formats LOOP`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       LOOP
         SELECT 1;
       END LOOP
@@ -11,7 +11,7 @@ describe("loops", () => {
   });
 
   it(`formats REPEAT`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       REPEAT
         SET x = x + 1;
       UNTIL x > 10 END REPEAT
@@ -19,7 +19,7 @@ describe("loops", () => {
   });
 
   it(`formats WHILE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       WHILE x < 10 DO
         SET x = x + 1;
       END WHILE
@@ -27,7 +27,7 @@ describe("loops", () => {
   });
 
   it(`formats FOR .. IN`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       FOR record IN (SELECT * FROM tbl) DO
         SELECT record.foo, record.bar;
       END FOR
@@ -35,7 +35,7 @@ describe("loops", () => {
   });
 
   it(`formats BREAK/CONTINUE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       LOOP
         IF TRUE THEN
           BREAK;
@@ -47,7 +47,7 @@ describe("loops", () => {
   });
 
   it(`formats labels`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       outer_loop: LOOP
         inner_loop: LOOP
           BREAK outer_loop;
@@ -57,7 +57,7 @@ describe("loops", () => {
   });
 
   it(`formats end labels`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       outer_loop: REPEAT
         inner_loop: LOOP
           CONTINUE outer_loop;

--- a/test/proc/loops.test.ts
+++ b/test/proc/loops.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("loops", () => {
-  it(`formats LOOP`, () => {
+  it(`formats LOOP`, async () => {
     testBigquery(dedent`
       LOOP
         SELECT 1;
@@ -10,7 +10,7 @@ describe("loops", () => {
     `);
   });
 
-  it(`formats REPEAT`, () => {
+  it(`formats REPEAT`, async () => {
     testBigquery(dedent`
       REPEAT
         SET x = x + 1;
@@ -18,7 +18,7 @@ describe("loops", () => {
     `);
   });
 
-  it(`formats WHILE`, () => {
+  it(`formats WHILE`, async () => {
     testBigquery(dedent`
       WHILE x < 10 DO
         SET x = x + 1;
@@ -26,7 +26,7 @@ describe("loops", () => {
     `);
   });
 
-  it(`formats FOR .. IN`, () => {
+  it(`formats FOR .. IN`, async () => {
     testBigquery(dedent`
       FOR record IN (SELECT * FROM tbl) DO
         SELECT record.foo, record.bar;
@@ -34,7 +34,7 @@ describe("loops", () => {
     `);
   });
 
-  it(`formats BREAK/CONTINUE`, () => {
+  it(`formats BREAK/CONTINUE`, async () => {
     testBigquery(dedent`
       LOOP
         IF TRUE THEN
@@ -46,7 +46,7 @@ describe("loops", () => {
     `);
   });
 
-  it(`formats labels`, () => {
+  it(`formats labels`, async () => {
     testBigquery(dedent`
       outer_loop: LOOP
         inner_loop: LOOP
@@ -56,7 +56,7 @@ describe("loops", () => {
     `);
   });
 
-  it(`formats end labels`, () => {
+  it(`formats end labels`, async () => {
     testBigquery(dedent`
       outer_loop: REPEAT
         inner_loop: LOOP

--- a/test/proc/prepared_statements.test.ts
+++ b/test/proc/prepared_statements.test.ts
@@ -3,13 +3,13 @@ import { testBigquery } from "../test_utils";
 
 describe("prepared statements", () => {
   it(`formats EXECUTE IMMEDIATE`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       EXECUTE IMMEDIATE 'SELECT * FROM tbl'
     `);
   });
 
   it(`formats EXECUTE IMMEDIATE with INTO and USING`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       EXECUTE IMMEDIATE 'SELECT ? + ?'
       INTO sum
       USING 1, 2
@@ -17,7 +17,7 @@ describe("prepared statements", () => {
   });
 
   it(`formats EXECUTE IMMEDIATE with long query`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       EXECUTE IMMEDIATE
         'SELECT count(*) FROM myschema.mytable WHERE operations > 10 AND name IS NOT NULL'
       INTO cnt

--- a/test/proc/prepared_statements.test.ts
+++ b/test/proc/prepared_statements.test.ts
@@ -2,13 +2,13 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("prepared statements", () => {
-  it(`formats EXECUTE IMMEDIATE`, () => {
+  it(`formats EXECUTE IMMEDIATE`, async () => {
     testBigquery(dedent`
       EXECUTE IMMEDIATE 'SELECT * FROM tbl'
     `);
   });
 
-  it(`formats EXECUTE IMMEDIATE with INTO and USING`, () => {
+  it(`formats EXECUTE IMMEDIATE with INTO and USING`, async () => {
     testBigquery(dedent`
       EXECUTE IMMEDIATE 'SELECT ? + ?'
       INTO sum
@@ -16,7 +16,7 @@ describe("prepared statements", () => {
     `);
   });
 
-  it(`formats EXECUTE IMMEDIATE with long query`, () => {
+  it(`formats EXECUTE IMMEDIATE with long query`, async () => {
     testBigquery(dedent`
       EXECUTE IMMEDIATE
         'SELECT count(*) FROM myschema.mytable WHERE operations > 10 AND name IS NOT NULL'

--- a/test/proc/raise.test.ts
+++ b/test/proc/raise.test.ts
@@ -2,13 +2,13 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("raise", () => {
-  it(`formats RAISE statement`, () => {
+  it(`formats RAISE statement`, async () => {
     testBigquery(dedent`
       RAISE
     `);
   });
 
-  it(`formats RAISE with message`, () => {
+  it(`formats RAISE with message`, async () => {
     testBigquery(dedent`
       RAISE USING MESSAGE = 'Serious error!'
     `);

--- a/test/proc/raise.test.ts
+++ b/test/proc/raise.test.ts
@@ -3,13 +3,13 @@ import { testBigquery } from "../test_utils";
 
 describe("raise", () => {
   it(`formats RAISE statement`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       RAISE
     `);
   });
 
   it(`formats RAISE with message`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       RAISE USING MESSAGE = 'Serious error!'
     `);
   });

--- a/test/proc/return.test.ts
+++ b/test/proc/return.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("return", () => {
-  it(`formats RETURN statement`, () => {
+  it(`formats RETURN statement`, async () => {
     testBigquery(dedent`
       RETURN
     `);

--- a/test/proc/return.test.ts
+++ b/test/proc/return.test.ts
@@ -3,7 +3,7 @@ import { testBigquery } from "../test_utils";
 
 describe("return", () => {
   it(`formats RETURN statement`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       RETURN
     `);
   });

--- a/test/proc/set.test.ts
+++ b/test/proc/set.test.ts
@@ -3,19 +3,19 @@ import { testBigquery } from "../test_utils";
 
 describe("set", () => {
   it(`formats basic SET statement`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       SET x = 1
     `);
   });
 
   it(`formats multi-assignment SET`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       SET (x, y, z) = (1, 2, 3)
     `);
   });
 
   it(`formats long SET expressions`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       SET (first_variable, second_variable) = (
         FORMAT('%d', word_count),
         FORMAT('%d', line_count)
@@ -24,7 +24,7 @@ describe("set", () => {
   });
 
   it(`formats long SET variable list`, async () => {
-    testBigquery(dedent`
+    await testBigquery(dedent`
       SET (
         first_variable,
         second_variable,

--- a/test/proc/set.test.ts
+++ b/test/proc/set.test.ts
@@ -2,19 +2,19 @@ import dedent from "dedent-js";
 import { testBigquery } from "../test_utils";
 
 describe("set", () => {
-  it(`formats basic SET statement`, () => {
+  it(`formats basic SET statement`, async () => {
     testBigquery(dedent`
       SET x = 1
     `);
   });
 
-  it(`formats multi-assignment SET`, () => {
+  it(`formats multi-assignment SET`, async () => {
     testBigquery(dedent`
       SET (x, y, z) = (1, 2, 3)
     `);
   });
 
-  it(`formats long SET expressions`, () => {
+  it(`formats long SET expressions`, async () => {
     testBigquery(dedent`
       SET (first_variable, second_variable) = (
         FORMAT('%d', word_count),
@@ -23,7 +23,7 @@ describe("set", () => {
     `);
   });
 
-  it(`formats long SET variable list`, () => {
+  it(`formats long SET variable list`, async () => {
     testBigquery(dedent`
       SET (
         first_variable,

--- a/test/select/from.test.ts
+++ b/test/select/from.test.ts
@@ -3,7 +3,7 @@ import { test, testBigquery } from "../test_utils";
 
 describe("select FROM", () => {
   it(`formats join always to multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client
@@ -12,7 +12,7 @@ describe("select FROM", () => {
   });
 
   it(`formats FROM with a long join to multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client_relation
@@ -21,7 +21,7 @@ describe("select FROM", () => {
   });
 
   it(`formats FROM with multiple joins to multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client
@@ -31,7 +31,7 @@ describe("select FROM", () => {
   });
 
   it(`formats FROM joins with USING-specification`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client
@@ -41,7 +41,7 @@ describe("select FROM", () => {
   });
 
   it(`formats long join specifications to separate lines`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client
@@ -53,7 +53,7 @@ describe("select FROM", () => {
   });
 
   it(`formats table aliases`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client AS c
@@ -62,7 +62,7 @@ describe("select FROM", () => {
   });
 
   it(`formats joins with subqueries`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client
@@ -72,7 +72,7 @@ describe("select FROM", () => {
   });
 
   it(`formats joins with table functions`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client
@@ -82,7 +82,7 @@ describe("select FROM", () => {
   });
 
   it(`formats comma-operator cross-joins`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client,
@@ -91,7 +91,7 @@ describe("select FROM", () => {
   });
 
   it(`formats indexing modifiers`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM
         client INDEXED BY my_idx
@@ -101,14 +101,14 @@ describe("select FROM", () => {
 
   describe("BigQuery", () => {
     it(`formats UNNEST()`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM UNNEST([10, 20, 30]) AS numbers WITH OFFSET
       `);
     });
 
     it(`formats PIVOT()`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM
           Produce
@@ -117,7 +117,7 @@ describe("select FROM", () => {
     });
 
     it(`formats long PIVOT() to multiple lines`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM
           Produce
@@ -130,7 +130,7 @@ describe("select FROM", () => {
     });
 
     it(`formats UNPIVOT()`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM
           Produce
@@ -139,7 +139,7 @@ describe("select FROM", () => {
     });
 
     it(`formats long UNPIVOT() with null-handling options to multiple lines`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM
           Produce
@@ -152,13 +152,13 @@ describe("select FROM", () => {
     });
 
     it(`formats TABLESPAMPLE operator`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT * FROM dataset.my_table TABLESAMPLE SYSTEM (10 PERCENT)
       `);
     });
 
     it(`formats TABLESPAMPLE operator to multiple lines`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM
           myLongProjectName.myCustomDatasetName.my_table_name
@@ -167,14 +167,14 @@ describe("select FROM", () => {
     });
 
     it(`formats FOR SYSTEM_TIME AS OF`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM tbl FOR SYSTEM_TIME AS OF '2017-01-01 10:00:00-07:00'
       `);
     });
 
     it(`formats long FOR SYSTEM_TIME AS OF to multiple lines`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM
           my_favorite_table AS fancy_table_name

--- a/test/select/from.test.ts
+++ b/test/select/from.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { test, testBigquery } from "../test_utils";
 
 describe("select FROM", () => {
-  it(`formats join always to multiple lines`, () => {
+  it(`formats join always to multiple lines`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -11,7 +11,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats FROM with a long join to multiple lines`, () => {
+  it(`formats FROM with a long join to multiple lines`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -20,7 +20,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats FROM with multiple joins to multiple lines`, () => {
+  it(`formats FROM with multiple joins to multiple lines`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -30,7 +30,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats FROM joins with USING-specification`, () => {
+  it(`formats FROM joins with USING-specification`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -40,7 +40,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats long join specifications to separate lines`, () => {
+  it(`formats long join specifications to separate lines`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -52,7 +52,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats table aliases`, () => {
+  it(`formats table aliases`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -61,7 +61,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats joins with subqueries`, () => {
+  it(`formats joins with subqueries`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -71,7 +71,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats joins with table functions`, () => {
+  it(`formats joins with table functions`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -81,7 +81,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats comma-operator cross-joins`, () => {
+  it(`formats comma-operator cross-joins`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -90,7 +90,7 @@ describe("select FROM", () => {
     `);
   });
 
-  it(`formats indexing modifiers`, () => {
+  it(`formats indexing modifiers`, async () => {
     test(dedent`
       SELECT *
       FROM
@@ -100,14 +100,14 @@ describe("select FROM", () => {
   });
 
   describe("BigQuery", () => {
-    it(`formats UNNEST()`, () => {
+    it(`formats UNNEST()`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM UNNEST([10, 20, 30]) AS numbers WITH OFFSET
       `);
     });
 
-    it(`formats PIVOT()`, () => {
+    it(`formats PIVOT()`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM
@@ -116,7 +116,7 @@ describe("select FROM", () => {
       `);
     });
 
-    it(`formats long PIVOT() to multiple lines`, () => {
+    it(`formats long PIVOT() to multiple lines`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM
@@ -129,7 +129,7 @@ describe("select FROM", () => {
       `);
     });
 
-    it(`formats UNPIVOT()`, () => {
+    it(`formats UNPIVOT()`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM
@@ -138,7 +138,7 @@ describe("select FROM", () => {
       `);
     });
 
-    it(`formats long UNPIVOT() with null-handling options to multiple lines`, () => {
+    it(`formats long UNPIVOT() with null-handling options to multiple lines`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM
@@ -151,13 +151,13 @@ describe("select FROM", () => {
       `);
     });
 
-    it(`formats TABLESPAMPLE operator`, () => {
+    it(`formats TABLESPAMPLE operator`, async () => {
       testBigquery(dedent`
         SELECT * FROM dataset.my_table TABLESAMPLE SYSTEM (10 PERCENT)
       `);
     });
 
-    it(`formats TABLESPAMPLE operator to multiple lines`, () => {
+    it(`formats TABLESPAMPLE operator to multiple lines`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM
@@ -166,14 +166,14 @@ describe("select FROM", () => {
       `);
     });
 
-    it(`formats FOR SYSTEM_TIME AS OF`, () => {
+    it(`formats FOR SYSTEM_TIME AS OF`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM tbl FOR SYSTEM_TIME AS OF '2017-01-01 10:00:00-07:00'
       `);
     });
 
-    it(`formats long FOR SYSTEM_TIME AS OF to multiple lines`, () => {
+    it(`formats long FOR SYSTEM_TIME AS OF to multiple lines`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM

--- a/test/select/select.test.ts
+++ b/test/select/select.test.ts
@@ -2,11 +2,11 @@ import dedent from "dedent-js";
 import { pretty, test, testBigquery } from "../test_utils";
 
 describe("select", () => {
-  it(`formats short SELECT..FROM..WHERE on single line`, () => {
+  it(`formats short SELECT..FROM..WHERE on single line`, async () => {
     test(`SELECT a, b, c FROM tbl WHERE x > y`);
   });
 
-  it(`forces multi-line format when the original select is already multi-line`, () => {
+  it(`forces multi-line format when the original select is already multi-line`, async () => {
     expect(pretty(`SELECT a, b, c \n FROM tbl WHERE x > y`)).toBe(dedent`
       SELECT a, b, c
       FROM tbl
@@ -14,7 +14,7 @@ describe("select", () => {
     `);
   });
 
-  it(`formats each SELECT clause to separate line`, () => {
+  it(`formats each SELECT clause to separate line`, async () => {
     test(dedent`
       SELECT *
       FROM tbl
@@ -26,7 +26,7 @@ describe("select", () => {
     `);
   });
 
-  it(`formats each SELECT clause with indented body when it doesn't fit on a single line`, () => {
+  it(`formats each SELECT clause with indented body when it doesn't fit on a single line`, async () => {
     expect(
       pretty(
         `SELECT very_long_col_name, another_long_col_name
@@ -60,7 +60,7 @@ describe("select", () => {
     `);
   });
 
-  it(`preserves multiline SELECT columns (even if they would fit on a single line)`, () => {
+  it(`preserves multiline SELECT columns (even if they would fit on a single line)`, async () => {
     test(dedent`
       SELECT
         col1,
@@ -69,11 +69,11 @@ describe("select", () => {
     `);
   });
 
-  it(`formats SELECT *`, () => {
+  it(`formats SELECT *`, async () => {
     test(`SELECT *`);
   });
 
-  it(`formats SELECT DISTINCT`, () => {
+  it(`formats SELECT DISTINCT`, async () => {
     test(
       dedent`
         SELECT DISTINCT
@@ -86,11 +86,11 @@ describe("select", () => {
     );
   });
 
-  it(`formats LIMIT with just count`, () => {
+  it(`formats LIMIT with just count`, async () => {
     test(`SELECT * FROM tbl LIMIT 10`);
   });
 
-  it(`formats set operations of select statements`, () => {
+  it(`formats set operations of select statements`, async () => {
     test(dedent`
       SELECT * FROM client WHERE status = 'inactive'
       UNION ALL
@@ -101,13 +101,13 @@ describe("select", () => {
   });
 
   describe("BigQuery", () => {
-    it(`removes trailing commas from SELECT`, () => {
+    it(`removes trailing commas from SELECT`, async () => {
       expect(pretty(`SELECT 1, 2, 3,`, { dialect: "bigquery" })).toBe(
         `SELECT 1, 2, 3`
       );
     });
 
-    it(`removes trailing commas from multiline SELECT`, () => {
+    it(`removes trailing commas from multiline SELECT`, async () => {
       expect(
         pretty(
           dedent`
@@ -132,27 +132,27 @@ describe("select", () => {
       );
     });
 
-    it(`formats SELECT * EXCEPT`, () => {
+    it(`formats SELECT * EXCEPT`, async () => {
       testBigquery(`SELECT * EXCEPT (order_id) FROM orders`);
     });
 
-    it(`formats SELECT * REPLACE`, () => {
+    it(`formats SELECT * REPLACE`, async () => {
       testBigquery(`SELECT * REPLACE (order_id AS id) FROM orders`);
     });
 
-    it(`formats SELECT AS STRUCT`, () => {
+    it(`formats SELECT AS STRUCT`, async () => {
       testBigquery(`SELECT AS STRUCT 1 AS a, 2 AS b`);
     });
 
-    it(`formats SELECT AS VALUE`, () => {
+    it(`formats SELECT AS VALUE`, async () => {
       testBigquery(`SELECT AS VALUE foo()`);
     });
 
-    it(`formats GROUP BY ROLLUP()`, () => {
+    it(`formats GROUP BY ROLLUP()`, async () => {
       testBigquery(`SELECT * FROM tbl GROUP BY ROLLUP(a, b, c)`);
     });
 
-    it(`formats GROUP BY ROLLUP() to multiple lines`, () => {
+    it(`formats GROUP BY ROLLUP() to multiple lines`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM my_table_name
@@ -166,11 +166,11 @@ describe("select", () => {
       `);
     });
 
-    it(`formats QUALIFY clause`, () => {
+    it(`formats QUALIFY clause`, async () => {
       testBigquery(`SELECT * FROM tbl QUALIFY x > 10`);
     });
 
-    it(`formats long QUALIFY clause to multiple lines`, () => {
+    it(`formats long QUALIFY clause to multiple lines`, async () => {
       testBigquery(dedent`
         SELECT *
         FROM my_table_name

--- a/test/select/select.test.ts
+++ b/test/select/select.test.ts
@@ -3,11 +3,11 @@ import { pretty, test, testBigquery } from "../test_utils";
 
 describe("select", () => {
   it(`formats short SELECT..FROM..WHERE on single line`, async () => {
-    test(`SELECT a, b, c FROM tbl WHERE x > y`);
+    await test(`SELECT a, b, c FROM tbl WHERE x > y`);
   });
 
   it(`forces multi-line format when the original select is already multi-line`, async () => {
-    expect(pretty(`SELECT a, b, c \n FROM tbl WHERE x > y`)).toBe(dedent`
+    expect(await pretty(`SELECT a, b, c \n FROM tbl WHERE x > y`)).toBe(dedent`
       SELECT a, b, c
       FROM tbl
       WHERE x > y
@@ -15,7 +15,7 @@ describe("select", () => {
   });
 
   it(`formats each SELECT clause to separate line`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM tbl
       WHERE x > y
@@ -28,7 +28,7 @@ describe("select", () => {
 
   it(`formats each SELECT clause with indented body when it doesn't fit on a single line`, async () => {
     expect(
-      pretty(
+      await pretty(
         `SELECT very_long_col_name, another_long_col_name
         FROM my_super_long_table_name
         WHERE my_table_name.x > my_table_name.y
@@ -61,7 +61,7 @@ describe("select", () => {
   });
 
   it(`preserves multiline SELECT columns (even if they would fit on a single line)`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT
         col1,
         col2,
@@ -70,11 +70,11 @@ describe("select", () => {
   });
 
   it(`formats SELECT *`, async () => {
-    test(`SELECT *`);
+    await test(`SELECT *`);
   });
 
   it(`formats SELECT DISTINCT`, async () => {
-    test(
+    await test(
       dedent`
         SELECT DISTINCT
           col1,
@@ -87,11 +87,11 @@ describe("select", () => {
   });
 
   it(`formats LIMIT with just count`, async () => {
-    test(`SELECT * FROM tbl LIMIT 10`);
+    await test(`SELECT * FROM tbl LIMIT 10`);
   });
 
   it(`formats set operations of select statements`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT * FROM client WHERE status = 'inactive'
       UNION ALL
       SELECT * FROM disabled_client
@@ -102,14 +102,14 @@ describe("select", () => {
 
   describe("BigQuery", () => {
     it(`removes trailing commas from SELECT`, async () => {
-      expect(pretty(`SELECT 1, 2, 3,`, { dialect: "bigquery" })).toBe(
+      expect(await pretty(`SELECT 1, 2, 3,`, { dialect: "bigquery" })).toBe(
         `SELECT 1, 2, 3`
       );
     });
 
     it(`removes trailing commas from multiline SELECT`, async () => {
       expect(
-        pretty(
+        await pretty(
           dedent`
             SELECT
               'something long',
@@ -133,27 +133,27 @@ describe("select", () => {
     });
 
     it(`formats SELECT * EXCEPT`, async () => {
-      testBigquery(`SELECT * EXCEPT (order_id) FROM orders`);
+      await testBigquery(`SELECT * EXCEPT (order_id) FROM orders`);
     });
 
     it(`formats SELECT * REPLACE`, async () => {
-      testBigquery(`SELECT * REPLACE (order_id AS id) FROM orders`);
+      await testBigquery(`SELECT * REPLACE (order_id AS id) FROM orders`);
     });
 
     it(`formats SELECT AS STRUCT`, async () => {
-      testBigquery(`SELECT AS STRUCT 1 AS a, 2 AS b`);
+      await testBigquery(`SELECT AS STRUCT 1 AS a, 2 AS b`);
     });
 
     it(`formats SELECT AS VALUE`, async () => {
-      testBigquery(`SELECT AS VALUE foo()`);
+      await testBigquery(`SELECT AS VALUE foo()`);
     });
 
     it(`formats GROUP BY ROLLUP()`, async () => {
-      testBigquery(`SELECT * FROM tbl GROUP BY ROLLUP(a, b, c)`);
+      await testBigquery(`SELECT * FROM tbl GROUP BY ROLLUP(a, b, c)`);
     });
 
     it(`formats GROUP BY ROLLUP() to multiple lines`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM my_table_name
         GROUP BY
@@ -167,11 +167,11 @@ describe("select", () => {
     });
 
     it(`formats QUALIFY clause`, async () => {
-      testBigquery(`SELECT * FROM tbl QUALIFY x > 10`);
+      await testBigquery(`SELECT * FROM tbl QUALIFY x > 10`);
     });
 
     it(`formats long QUALIFY clause to multiple lines`, async () => {
-      testBigquery(dedent`
+      await testBigquery(dedent`
         SELECT *
         FROM my_table_name
         QUALIFY

--- a/test/select/window.test.ts
+++ b/test/select/window.test.ts
@@ -3,7 +3,7 @@ import { test } from "../test_utils";
 
 describe("select", () => {
   it(`formats short window clause on single lines`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM tbl
       WINDOW my_win AS (PARTITION BY col1)
@@ -11,7 +11,7 @@ describe("select", () => {
   });
 
   it(`formats multiple window definitions on separate lines`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM tbl
       WINDOW
@@ -21,7 +21,7 @@ describe("select", () => {
   });
 
   it(`formats long window definitions on multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       SELECT *
       FROM tbl
       WINDOW
@@ -43,7 +43,7 @@ describe("select", () => {
   });
 
   it("formats basic window function calls, referencing named window", async () => {
-    test(dedent`
+    await test(dedent`
       SELECT row_number() OVER win1
       FROM tbl
       WINDOW win1 AS (ORDER BY x)
@@ -51,14 +51,14 @@ describe("select", () => {
   });
 
   it("formats short window function calls on single line", async () => {
-    test(dedent`
+    await test(dedent`
       SELECT row_number() OVER (ORDER BY x)
       FROM tbl
     `);
   });
 
   it("formats longer window function calls on multiple lines", async () => {
-    test(dedent`
+    await test(dedent`
       SELECT
         row_number() OVER (
           PARTITION BY y
@@ -69,14 +69,14 @@ describe("select", () => {
   });
 
   it("formats window function call with short FILTER clause on single line", async () => {
-    test(dedent`
+    await test(dedent`
       SELECT row_number() FILTER (WHERE x > 10) OVER (ORDER BY x)
       FROM tbl
     `);
   });
 
   it("formats window function call with longer FILTER and OVER clauses on multiple lines", async () => {
-    test(dedent`
+    await test(dedent`
       SELECT
         group_concat(entity_name, '.')
           FILTER (WHERE entity_type IS NOT NULL)

--- a/test/select/window.test.ts
+++ b/test/select/window.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { test } from "../test_utils";
 
 describe("select", () => {
-  it(`formats short window clause on single lines`, () => {
+  it(`formats short window clause on single lines`, async () => {
     test(dedent`
       SELECT *
       FROM tbl
@@ -10,7 +10,7 @@ describe("select", () => {
     `);
   });
 
-  it(`formats multiple window definitions on separate lines`, () => {
+  it(`formats multiple window definitions on separate lines`, async () => {
     test(dedent`
       SELECT *
       FROM tbl
@@ -20,7 +20,7 @@ describe("select", () => {
     `);
   });
 
-  it(`formats long window definitions on multiple lines`, () => {
+  it(`formats long window definitions on multiple lines`, async () => {
     test(dedent`
       SELECT *
       FROM tbl
@@ -42,7 +42,7 @@ describe("select", () => {
     `);
   });
 
-  it("formats basic window function calls, referencing named window", () => {
+  it("formats basic window function calls, referencing named window", async () => {
     test(dedent`
       SELECT row_number() OVER win1
       FROM tbl
@@ -50,14 +50,14 @@ describe("select", () => {
     `);
   });
 
-  it("formats short window function calls on single line", () => {
+  it("formats short window function calls on single line", async () => {
     test(dedent`
       SELECT row_number() OVER (ORDER BY x)
       FROM tbl
     `);
   });
 
-  it("formats longer window function calls on multiple lines", () => {
+  it("formats longer window function calls on multiple lines", async () => {
     test(dedent`
       SELECT
         row_number() OVER (
@@ -68,14 +68,14 @@ describe("select", () => {
     `);
   });
 
-  it("formats window function call with short FILTER clause on single line", () => {
+  it("formats window function call with short FILTER clause on single line", async () => {
     test(dedent`
       SELECT row_number() FILTER (WHERE x > 10) OVER (ORDER BY x)
       FROM tbl
     `);
   });
 
-  it("formats window function call with longer FILTER and OVER clauses on multiple lines", () => {
+  it("formats window function call with longer FILTER and OVER clauses on multiple lines", async () => {
     test(dedent`
       SELECT
         group_concat(entity_name, '.')

--- a/test/select/with.test.ts
+++ b/test/select/with.test.ts
@@ -2,13 +2,13 @@ import dedent from "dedent-js";
 import { test } from "../test_utils";
 
 describe("select with", () => {
-  it(`formats tiny WITH on same line as the rest of SELECT`, () => {
+  it(`formats tiny WITH on same line as the rest of SELECT`, async () => {
     test(dedent`
       WITH cte1 AS (SELECT * FROM client) SELECT * FROM cte1
     `);
   });
 
-  it(`formats short WITH clause on single line inside multiline SELECT`, () => {
+  it(`formats short WITH clause on single line inside multiline SELECT`, async () => {
     test(dedent`
       WITH cte1 AS (SELECT * FROM client)
       SELECT *
@@ -16,7 +16,7 @@ describe("select with", () => {
     `);
   });
 
-  it(`formats long WITH clause on multiple lines`, () => {
+  it(`formats long WITH clause on multiple lines`, async () => {
     test(dedent`
       WITH
         cte1 AS (SELECT * FROM client WHERE age > 100),
@@ -26,7 +26,7 @@ describe("select with", () => {
     `);
   });
 
-  it(`formats WITH clause with various options`, () => {
+  it(`formats WITH clause with various options`, async () => {
     test(dedent`
       WITH RECURSIVE
         cte1 AS MATERIALIZED (SELECT * FROM client WHERE age > 100),
@@ -36,7 +36,7 @@ describe("select with", () => {
     `);
   });
 
-  it(`formats SELECT inside CTE on multiple lines`, () => {
+  it(`formats SELECT inside CTE on multiple lines`, async () => {
     test(dedent`
       WITH RECURSIVE
         cte1 AS (
@@ -49,7 +49,7 @@ describe("select with", () => {
     `);
   });
 
-  it(`formats CTE with column names list`, () => {
+  it(`formats CTE with column names list`, async () => {
     test(dedent`
       WITH oldies(id, name) AS (SELECT * FROM client WHERE age > 100)
       SELECT *

--- a/test/select/with.test.ts
+++ b/test/select/with.test.ts
@@ -3,13 +3,13 @@ import { test } from "../test_utils";
 
 describe("select with", () => {
   it(`formats tiny WITH on same line as the rest of SELECT`, async () => {
-    test(dedent`
+    await test(dedent`
       WITH cte1 AS (SELECT * FROM client) SELECT * FROM cte1
     `);
   });
 
   it(`formats short WITH clause on single line inside multiline SELECT`, async () => {
-    test(dedent`
+    await test(dedent`
       WITH cte1 AS (SELECT * FROM client)
       SELECT *
       FROM cte1
@@ -17,7 +17,7 @@ describe("select with", () => {
   });
 
   it(`formats long WITH clause on multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       WITH
         cte1 AS (SELECT * FROM client WHERE age > 100),
         cte2 AS (SELECT * FROM client WHERE age < 10)
@@ -27,7 +27,7 @@ describe("select with", () => {
   });
 
   it(`formats WITH clause with various options`, async () => {
-    test(dedent`
+    await test(dedent`
       WITH RECURSIVE
         cte1 AS MATERIALIZED (SELECT * FROM client WHERE age > 100),
         cte2 AS NOT MATERIALIZED (SELECT * FROM client WHERE age < 10)
@@ -37,7 +37,7 @@ describe("select with", () => {
   });
 
   it(`formats SELECT inside CTE on multiple lines`, async () => {
-    test(dedent`
+    await test(dedent`
       WITH RECURSIVE
         cte1 AS (
           SELECT *
@@ -50,7 +50,7 @@ describe("select with", () => {
   });
 
   it(`formats CTE with column names list`, async () => {
-    test(dedent`
+    await test(dedent`
       WITH oldies(id, name) AS (SELECT * FROM client WHERE age > 100)
       SELECT *
       FROM oldies

--- a/test/sqlite/attach_detach.test.ts
+++ b/test/sqlite/attach_detach.test.ts
@@ -1,19 +1,19 @@
 import { test } from "../test_utils";
 
 describe("attach/detach", () => {
-  it(`formats ATTACH DATABASE statement`, () => {
+  it(`formats ATTACH DATABASE statement`, async () => {
     test(`ATTACH DATABASE 'my_file.sqlite' AS my_schema`);
   });
 
-  it(`formats plain ATTACH statement (without DATABASE keyword)`, () => {
+  it(`formats plain ATTACH statement (without DATABASE keyword)`, async () => {
     test(`ATTACH 'my_file.sqlite' AS my_schema`);
   });
 
-  it(`formats DETACH DATABASE statement`, () => {
+  it(`formats DETACH DATABASE statement`, async () => {
     test(`DETACH DATABASE my_schema`);
   });
 
-  it(`formats plain DETACH statement (without DATABASE keyword)`, () => {
+  it(`formats plain DETACH statement (without DATABASE keyword)`, async () => {
     test(`DETACH my_schema`);
   });
 });

--- a/test/sqlite/attach_detach.test.ts
+++ b/test/sqlite/attach_detach.test.ts
@@ -2,18 +2,18 @@ import { test } from "../test_utils";
 
 describe("attach/detach", () => {
   it(`formats ATTACH DATABASE statement`, async () => {
-    test(`ATTACH DATABASE 'my_file.sqlite' AS my_schema`);
+    await test(`ATTACH DATABASE 'my_file.sqlite' AS my_schema`);
   });
 
   it(`formats plain ATTACH statement (without DATABASE keyword)`, async () => {
-    test(`ATTACH 'my_file.sqlite' AS my_schema`);
+    await test(`ATTACH 'my_file.sqlite' AS my_schema`);
   });
 
   it(`formats DETACH DATABASE statement`, async () => {
-    test(`DETACH DATABASE my_schema`);
+    await test(`DETACH DATABASE my_schema`);
   });
 
   it(`formats plain DETACH statement (without DATABASE keyword)`, async () => {
-    test(`DETACH my_schema`);
+    await test(`DETACH my_schema`);
   });
 });

--- a/test/sqlite/pragma.test.ts
+++ b/test/sqlite/pragma.test.ts
@@ -2,14 +2,14 @@ import { test } from "../test_utils";
 
 describe("pragma", () => {
   it(`formats reading of PRAGMA value`, async () => {
-    test(`PRAGMA function_list`);
+    await test(`PRAGMA function_list`);
   });
 
   it(`formats PRAGMA assignment`, async () => {
-    test(`PRAGMA encoding = 'UTF-8'`);
+    await test(`PRAGMA encoding = 'UTF-8'`);
   });
 
   it(`formats PRAGMA function call`, async () => {
-    test(`PRAGMA my_schema.wal_checkpoint(PASSIVE)`);
+    await test(`PRAGMA my_schema.wal_checkpoint(PASSIVE)`);
   });
 });

--- a/test/sqlite/pragma.test.ts
+++ b/test/sqlite/pragma.test.ts
@@ -1,15 +1,15 @@
 import { test } from "../test_utils";
 
 describe("pragma", () => {
-  it(`formats reading of PRAGMA value`, () => {
+  it(`formats reading of PRAGMA value`, async () => {
     test(`PRAGMA function_list`);
   });
 
-  it(`formats PRAGMA assignment`, () => {
+  it(`formats PRAGMA assignment`, async () => {
     test(`PRAGMA encoding = 'UTF-8'`);
   });
 
-  it(`formats PRAGMA function call`, () => {
+  it(`formats PRAGMA function call`, async () => {
     test(`PRAGMA my_schema.wal_checkpoint(PASSIVE)`);
   });
 });

--- a/test/sqlite/reindex.test.ts
+++ b/test/sqlite/reindex.test.ts
@@ -2,10 +2,10 @@ import { test } from "../test_utils";
 
 describe("reindex", () => {
   it(`formats REINDEX`, async () => {
-    test(`REINDEX my_schema.my_table`);
+    await test(`REINDEX my_schema.my_table`);
   });
 
   it(`formats plain REINDEX`, async () => {
-    test(`REINDEX`);
+    await test(`REINDEX`);
   });
 });

--- a/test/sqlite/reindex.test.ts
+++ b/test/sqlite/reindex.test.ts
@@ -1,11 +1,11 @@
 import { test } from "../test_utils";
 
 describe("reindex", () => {
-  it(`formats REINDEX`, () => {
+  it(`formats REINDEX`, async () => {
     test(`REINDEX my_schema.my_table`);
   });
 
-  it(`formats plain REINDEX`, () => {
+  it(`formats plain REINDEX`, async () => {
     test(`REINDEX`);
   });
 });

--- a/test/sqlite/vacuum.test.ts
+++ b/test/sqlite/vacuum.test.ts
@@ -1,19 +1,19 @@
 import { test } from "../test_utils";
 
 describe("vacuum", () => {
-  it(`formats VACUUM schema INTO file`, () => {
+  it(`formats VACUUM schema INTO file`, async () => {
     test(`VACUUM my_schema INTO 'my_file.sqlite'`);
   });
 
-  it(`formats plain VACUUM statement`, () => {
+  it(`formats plain VACUUM statement`, async () => {
     test(`VACUUM`);
   });
 
-  it(`formats VACUUM with just schema`, () => {
+  it(`formats VACUUM with just schema`, async () => {
     test(`VACUUM my_schema`);
   });
 
-  it(`formats VACUUM with just INTO`, () => {
+  it(`formats VACUUM with just INTO`, async () => {
     test(`VACUUM INTO 'my_file.sqlite'`);
   });
 });

--- a/test/sqlite/vacuum.test.ts
+++ b/test/sqlite/vacuum.test.ts
@@ -2,18 +2,18 @@ import { test } from "../test_utils";
 
 describe("vacuum", () => {
   it(`formats VACUUM schema INTO file`, async () => {
-    test(`VACUUM my_schema INTO 'my_file.sqlite'`);
+    await test(`VACUUM my_schema INTO 'my_file.sqlite'`);
   });
 
   it(`formats plain VACUUM statement`, async () => {
-    test(`VACUUM`);
+    await test(`VACUUM`);
   });
 
   it(`formats VACUUM with just schema`, async () => {
-    test(`VACUUM my_schema`);
+    await test(`VACUUM my_schema`);
   });
 
   it(`formats VACUUM with just INTO`, async () => {
-    test(`VACUUM INTO 'my_file.sqlite'`);
+    await test(`VACUUM INTO 'my_file.sqlite'`);
   });
 });

--- a/test/sqlite/virtual_table.test.ts
+++ b/test/sqlite/virtual_table.test.ts
@@ -2,14 +2,14 @@ import dedent from "dedent-js";
 import { test } from "../test_utils";
 
 describe("create virtual table", () => {
-  it(`formats CREATE VIRTUAL TABLE`, () => {
+  it(`formats CREATE VIRTUAL TABLE`, async () => {
     test(dedent`
       CREATE VIRTUAL TABLE my_table
       USING my_func(1, 2)
     `);
   });
 
-  it(`formats IF NOT EXISTS`, () => {
+  it(`formats IF NOT EXISTS`, async () => {
     test(dedent`
       CREATE VIRTUAL TABLE IF NOT EXISTS my_table
       USING my_func(1, 2)

--- a/test/sqlite/virtual_table.test.ts
+++ b/test/sqlite/virtual_table.test.ts
@@ -3,14 +3,14 @@ import { test } from "../test_utils";
 
 describe("create virtual table", () => {
   it(`formats CREATE VIRTUAL TABLE`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE VIRTUAL TABLE my_table
       USING my_func(1, 2)
     `);
   });
 
   it(`formats IF NOT EXISTS`, async () => {
-    test(dedent`
+    await test(dedent`
       CREATE VIRTUAL TABLE IF NOT EXISTS my_table
       USING my_func(1, 2)
     `);

--- a/test/statement.test.ts
+++ b/test/statement.test.ts
@@ -4,21 +4,21 @@ import { rawPretty, rawTest } from "./test_utils";
 // In these tests we use rawPretty()
 // to also test that formatted file always ends with final newline.
 describe("statement", () => {
-  it(`adds semicolon to statement without a semicolon`, () => {
+  it(`adds semicolon to statement without a semicolon`, async () => {
     expect(rawPretty(`SELECT 1`)).toBe(dedent`
       SELECT 1;
 
     `);
   });
 
-  it(`formats statement ending with semicolon`, () => {
+  it(`formats statement ending with semicolon`, async () => {
     expect(rawPretty(`SELECT 1;`)).toBe(dedent`
       SELECT 1;
 
     `);
   });
 
-  it(`formats multiple statements`, () => {
+  it(`formats multiple statements`, async () => {
     expect(rawPretty(`SELECT 1; SELECT 2; SELECT 3;`)).toBe(dedent`
       SELECT 1;
       SELECT 2;
@@ -27,7 +27,7 @@ describe("statement", () => {
     `);
   });
 
-  it(`ensures semicolon after last statement`, () => {
+  it(`ensures semicolon after last statement`, async () => {
     expect(rawPretty(`SELECT 1; SELECT 2; SELECT 3`)).toBe(dedent`
       SELECT 1;
       SELECT 2;
@@ -36,7 +36,7 @@ describe("statement", () => {
     `);
   });
 
-  it(`preserves empty line between statements`, () => {
+  it(`preserves empty line between statements`, async () => {
     rawTest(dedent`
       SELECT 1;
 
@@ -49,7 +49,7 @@ describe("statement", () => {
     `);
   });
 
-  it(`replaces multiple empty lines with just one`, () => {
+  it(`replaces multiple empty lines with just one`, async () => {
     expect(
       rawPretty(dedent`
         SELECT 1;

--- a/test/statement.test.ts
+++ b/test/statement.test.ts
@@ -5,21 +5,21 @@ import { rawPretty, rawTest } from "./test_utils";
 // to also test that formatted file always ends with final newline.
 describe("statement", () => {
   it(`adds semicolon to statement without a semicolon`, async () => {
-    expect(rawPretty(`SELECT 1`)).toBe(dedent`
+    expect(await rawPretty(`SELECT 1`)).toBe(dedent`
       SELECT 1;
 
     `);
   });
 
   it(`formats statement ending with semicolon`, async () => {
-    expect(rawPretty(`SELECT 1;`)).toBe(dedent`
+    expect(await rawPretty(`SELECT 1;`)).toBe(dedent`
       SELECT 1;
 
     `);
   });
 
   it(`formats multiple statements`, async () => {
-    expect(rawPretty(`SELECT 1; SELECT 2; SELECT 3;`)).toBe(dedent`
+    expect(await rawPretty(`SELECT 1; SELECT 2; SELECT 3;`)).toBe(dedent`
       SELECT 1;
       SELECT 2;
       SELECT 3;
@@ -28,7 +28,7 @@ describe("statement", () => {
   });
 
   it(`ensures semicolon after last statement`, async () => {
-    expect(rawPretty(`SELECT 1; SELECT 2; SELECT 3`)).toBe(dedent`
+    expect(await rawPretty(`SELECT 1; SELECT 2; SELECT 3`)).toBe(dedent`
       SELECT 1;
       SELECT 2;
       SELECT 3;
@@ -51,7 +51,7 @@ describe("statement", () => {
 
   it(`replaces multiple empty lines with just one`, async () => {
     expect(
-      rawPretty(dedent`
+      await rawPretty(dedent`
         SELECT 1;
 
 

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -38,5 +38,5 @@ export const test = async (sql: string, opts: TestOptions = {}): Promise<void> =
 };
 
 export const testBigquery = async (sql: string, opts: TestOptions = {}): Promise<void> => {
-  await test(sql, { dialect: "bigquery", ...opts });
+  await await test(sql, { dialect: "bigquery", ...opts });
 };

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -11,7 +11,7 @@ interface TestOptions extends PrettyOptions {
   dialect?: DialectName;
 }
 
-export const rawPretty = (sql: string, opts: TestOptions = {}): string => {
+export const rawPretty = async (sql: string, opts: TestOptions = {}): Promise<string> => {
   return format(sql, {
     parser: opts.dialect ?? "sqlite",
     plugins: [plugin],
@@ -19,8 +19,8 @@ export const rawPretty = (sql: string, opts: TestOptions = {}): string => {
   });
 };
 
-export const pretty = (sql: string, opts: TestOptions = {}): string => {
-  const formatted = rawPretty(sql, opts);
+export const pretty = async (sql: string, opts: TestOptions = {}): Promise<string> => {
+  const formatted = await rawPretty(sql, opts);
   if (!/;\n$/.test(formatted)) {
     throw new Error(
       `Expected semicolon and newline at the end of:\n${formatted}`
@@ -29,14 +29,14 @@ export const pretty = (sql: string, opts: TestOptions = {}): string => {
   return formatted.replace(/;\n$/, "");
 };
 
-export const rawTest = (sql: string, opts: TestOptions = {}): void => {
-  expect(rawPretty(sql, opts)).toBe(sql);
+export const rawTest = async (sql: string, opts: TestOptions = {}): Promise<void> => {
+  expect(await rawPretty(sql, opts)).toBe(sql);
 };
 
-export const test = (sql: string, opts: TestOptions = {}): void => {
-  expect(pretty(sql, opts)).toBe(sql);
+export const test = async (sql: string, opts: TestOptions = {}): Promise<void> => {
+  expect(await pretty(sql, opts)).toBe(sql);
 };
 
-export const testBigquery = (sql: string, opts: TestOptions = {}): void => {
-  test(sql, { dialect: "bigquery", ...opts });
+export const testBigquery = async (sql: string, opts: TestOptions = {}): Promise<void> => {
+  await test(sql, { dialect: "bigquery", ...opts });
 };

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -2,7 +2,7 @@ import dedent from "dedent-js";
 import { rawTest } from "./test_utils";
 
 describe("transaction", () => {
-  it(`formats basic BEGIN..COMMIT`, () => {
+  it(`formats basic BEGIN..COMMIT`, async () => {
     rawTest(dedent`
       BEGIN;
 
@@ -13,7 +13,7 @@ describe("transaction", () => {
     `);
   });
 
-  it(`formats basic BEGIN..END`, () => {
+  it(`formats basic BEGIN..END`, async () => {
     rawTest(dedent`
       BEGIN;
 
@@ -24,7 +24,7 @@ describe("transaction", () => {
     `);
   });
 
-  it(`formats BEGIN TRANSACTION .. COMMIT TRANSACTION`, () => {
+  it(`formats BEGIN TRANSACTION .. COMMIT TRANSACTION`, async () => {
     rawTest(dedent`
       BEGIN TRANSACTION;
 
@@ -35,14 +35,14 @@ describe("transaction", () => {
     `);
   });
 
-  it(`formats BEGIN DEFERRED TRANSACTION`, () => {
+  it(`formats BEGIN DEFERRED TRANSACTION`, async () => {
     rawTest(dedent`
       BEGIN DEFERRED TRANSACTION;
 
     `);
   });
 
-  it(`formats ROLLBACK`, () => {
+  it(`formats ROLLBACK`, async () => {
     rawTest(dedent`
       ROLLBACK;
 
@@ -55,14 +55,14 @@ describe("transaction", () => {
     `);
   });
 
-  it(`formats SAVEPOINT`, () => {
+  it(`formats SAVEPOINT`, async () => {
     rawTest(dedent`
       SAVEPOINT my_savepoint;
 
     `);
   });
 
-  it(`formats RELEASE SAVEPOINT`, () => {
+  it(`formats RELEASE SAVEPOINT`, async () => {
     rawTest(dedent`
       RELEASE my_savepoint;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,10 +1852,10 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prettier@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.2.tgz#c4ea1b5b454d7c4b59966db2e06ed7eec5dfd160"
-  integrity sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==
+prettier@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 pretty-format@^29.0.0, pretty-format@^29.3.1:
   version "29.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,7 +268,7 @@
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
 
-"@babel/traverse@^7.20.10", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.7", "@babel/traverse@^7.7.2":
+"@babel/traverse@^7.20.10", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.7":
   version "7.20.12"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.12.tgz#7f0f787b3a67ca4475adef1f56cb94f6abd4a4b5"
   integrity sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==
@@ -314,61 +314,61 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jest/console@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.3.1.tgz#3e3f876e4e47616ea3b1464b9fbda981872e9583"
-  integrity sha512-IRE6GD47KwcqA09RIWrabKdHPiKDGgtAL31xDxbi/RjQMsr+lY+ppxmHwY0dUEV3qvvxZzoe5Hl0RXZJOjQNUg==
+"@jest/console@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"
+  integrity sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==
   dependencies:
-    "@jest/types" "^29.3.1"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
-    jest-message-util "^29.3.1"
-    jest-util "^29.3.1"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
     slash "^3.0.0"
 
-"@jest/core@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.3.1.tgz#bff00f413ff0128f4debec1099ba7dcd649774a1"
-  integrity sha512-0ohVjjRex985w5MmO5L3u5GR1O30DexhBSpuwx2P+9ftyqHdJXnk7IUWiP80oHMvt7ubHCJHxV0a0vlKVuZirw==
+"@jest/core@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.7.0.tgz#b6cccc239f30ff36609658c5a5e2291757ce448f"
+  integrity sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==
   dependencies:
-    "@jest/console" "^29.3.1"
-    "@jest/reporters" "^29.3.1"
-    "@jest/test-result" "^29.3.1"
-    "@jest/transform" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/console" "^29.7.0"
+    "@jest/reporters" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     exit "^0.1.2"
     graceful-fs "^4.2.9"
-    jest-changed-files "^29.2.0"
-    jest-config "^29.3.1"
-    jest-haste-map "^29.3.1"
-    jest-message-util "^29.3.1"
-    jest-regex-util "^29.2.0"
-    jest-resolve "^29.3.1"
-    jest-resolve-dependencies "^29.3.1"
-    jest-runner "^29.3.1"
-    jest-runtime "^29.3.1"
-    jest-snapshot "^29.3.1"
-    jest-util "^29.3.1"
-    jest-validate "^29.3.1"
-    jest-watcher "^29.3.1"
+    jest-changed-files "^29.7.0"
+    jest-config "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-resolve-dependencies "^29.7.0"
+    jest-runner "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    jest-watcher "^29.7.0"
     micromatch "^4.0.4"
-    pretty-format "^29.3.1"
+    pretty-format "^29.7.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.3.1.tgz#eb039f726d5fcd14698acd072ac6576d41cfcaa6"
-  integrity sha512-pMmvfOPmoa1c1QpfFW0nXYtNLpofqo4BrCIk6f2kW4JFeNlHV2t3vd+3iDLf31e2ot2Mec0uqZfmI+U0K2CFag==
+"@jest/environment@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
+  integrity sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==
   dependencies:
-    "@jest/fake-timers" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
-    jest-mock "^29.3.1"
+    jest-mock "^29.7.0"
 
 "@jest/expect-utils@^29.3.1":
   version "29.3.1"
@@ -377,47 +377,54 @@
   dependencies:
     jest-get-type "^29.2.0"
 
-"@jest/expect@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.3.1.tgz#456385b62894349c1d196f2d183e3716d4c6a6cd"
-  integrity sha512-QivM7GlSHSsIAWzgfyP8dgeExPRZ9BIe2LsdPyEhCGkZkoyA+kGsoIzbKAfZCvvRzfZioKwPtCZIt5SaoxYCvg==
+"@jest/expect-utils@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
+  integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
   dependencies:
-    expect "^29.3.1"
-    jest-snapshot "^29.3.1"
+    jest-get-type "^29.6.3"
 
-"@jest/fake-timers@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.3.1.tgz#b140625095b60a44de820876d4c14da1aa963f67"
-  integrity sha512-iHTL/XpnDlFki9Tq0Q1GGuVeQ8BHZGIYsvCO5eN/O/oJaRzofG9Xndd9HuSDBI/0ZS79pg0iwn07OMTQ7ngF2A==
+"@jest/expect@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.7.0.tgz#76a3edb0cb753b70dfbfe23283510d3d45432bf2"
+  integrity sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==
   dependencies:
-    "@jest/types" "^29.3.1"
-    "@sinonjs/fake-timers" "^9.1.2"
+    expect "^29.7.0"
+    jest-snapshot "^29.7.0"
+
+"@jest/fake-timers@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565"
+  integrity sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@sinonjs/fake-timers" "^10.0.2"
     "@types/node" "*"
-    jest-message-util "^29.3.1"
-    jest-mock "^29.3.1"
-    jest-util "^29.3.1"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
 
-"@jest/globals@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.3.1.tgz#92be078228e82d629df40c3656d45328f134a0c6"
-  integrity sha512-cTicd134vOcwO59OPaB6AmdHQMCtWOe+/DitpTZVxWgMJ+YvXL1HNAmPyiGbSHmF/mXVBkvlm8YYtQhyHPnV6Q==
+"@jest/globals@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d"
+  integrity sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==
   dependencies:
-    "@jest/environment" "^29.3.1"
-    "@jest/expect" "^29.3.1"
-    "@jest/types" "^29.3.1"
-    jest-mock "^29.3.1"
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    jest-mock "^29.7.0"
 
-"@jest/reporters@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.3.1.tgz#9a6d78c109608e677c25ddb34f907b90e07b4310"
-  integrity sha512-GhBu3YFuDrcAYW/UESz1JphEAbvUjaY2vShRZRoRY1mxpCMB3yGSJ4j9n0GxVlEOdCf7qjvUfBCrTUUqhVfbRA==
+"@jest/reporters@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.7.0.tgz#04b262ecb3b8faa83b0b3d321623972393e8f4c7"
+  integrity sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^29.3.1"
-    "@jest/test-result" "^29.3.1"
-    "@jest/transform" "^29.3.1"
-    "@jest/types" "^29.3.1"
-    "@jridgewell/trace-mapping" "^0.3.15"
+    "@jest/console" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
     "@types/node" "*"
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
@@ -425,13 +432,13 @@
     glob "^7.1.3"
     graceful-fs "^4.2.9"
     istanbul-lib-coverage "^3.0.0"
-    istanbul-lib-instrument "^5.1.0"
+    istanbul-lib-instrument "^6.0.0"
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
     istanbul-reports "^3.1.3"
-    jest-message-util "^29.3.1"
-    jest-util "^29.3.1"
-    jest-worker "^29.3.1"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
     slash "^3.0.0"
     string-length "^4.0.1"
     strip-ansi "^6.0.0"
@@ -444,55 +451,62 @@
   dependencies:
     "@sinclair/typebox" "^0.24.1"
 
-"@jest/source-map@^29.2.0":
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.2.0.tgz#ab3420c46d42508dcc3dc1c6deee0b613c235744"
-  integrity sha512-1NX9/7zzI0nqa6+kgpSdKPK+WU1p+SJk3TloWZf5MzPbxri9UEeXX5bWZAPCzbQcyuAzubcdUHA7hcNznmRqWQ==
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.15"
+    "@sinclair/typebox" "^0.27.8"
+
+"@jest/source-map@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.6.3.tgz#d90ba772095cf37a34a5eb9413f1b562a08554c4"
+  integrity sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.18"
     callsites "^3.0.0"
     graceful-fs "^4.2.9"
 
-"@jest/test-result@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.3.1.tgz#92cd5099aa94be947560a24610aa76606de78f50"
-  integrity sha512-qeLa6qc0ddB0kuOZyZIhfN5q0e2htngokyTWsGriedsDhItisW7SDYZ7ceOe57Ii03sL988/03wAcBh3TChMGw==
+"@jest/test-result@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.7.0.tgz#8db9a80aa1a097bb2262572686734baed9b1657c"
+  integrity sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==
   dependencies:
-    "@jest/console" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/console" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.3.1.tgz#fa24b3b050f7a59d48f7ef9e0b782ab65123090d"
-  integrity sha512-IqYvLbieTv20ArgKoAMyhLHNrVHJfzO6ARZAbQRlY4UGWfdDnLlZEF0BvKOMd77uIiIjSZRwq3Jb3Fa3I8+2UA==
+"@jest/test-sequencer@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz#6cef977ce1d39834a3aea887a1726628a6f072ce"
+  integrity sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==
   dependencies:
-    "@jest/test-result" "^29.3.1"
+    "@jest/test-result" "^29.7.0"
     graceful-fs "^4.2.9"
-    jest-haste-map "^29.3.1"
+    jest-haste-map "^29.7.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.3.1.tgz#1e6bd3da4af50b5c82a539b7b1f3770568d6e36d"
-  integrity sha512-8wmCFBTVGYqFNLWfcOWoVuMuKYPUBTnTMDkdvFtAYELwDOl9RGwOsvQWGPFxDJ8AWY9xM/8xCXdqmPK3+Q5Lug==
+"@jest/transform@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.7.0.tgz#df2dd9c346c7d7768b8a06639994640c642e284c"
+  integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/types" "^29.3.1"
-    "@jridgewell/trace-mapping" "^0.3.15"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
     babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
     convert-source-map "^2.0.0"
     fast-json-stable-stringify "^2.1.0"
     graceful-fs "^4.2.9"
-    jest-haste-map "^29.3.1"
-    jest-regex-util "^29.2.0"
-    jest-util "^29.3.1"
+    jest-haste-map "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
     micromatch "^4.0.4"
     pirates "^4.0.4"
     slash "^3.0.0"
-    write-file-atomic "^4.0.1"
+    write-file-atomic "^4.0.2"
 
 "@jest/types@^29.3.1":
   version "29.3.1"
@@ -500,6 +514,18 @@
   integrity sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==
   dependencies:
     "@jest/schemas" "^29.0.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
@@ -528,6 +554,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
 "@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
@@ -538,7 +569,12 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.15", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
   integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
@@ -546,24 +582,37 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@jridgewell/trace-mapping@^0.3.18":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz#f8a3249862f91be48d3127c3cfe992f79b4b8811"
+  integrity sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
   integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
 
-"@sinonjs/commons@^1.7.0":
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
-  integrity sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
+"@sinonjs/commons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^9.1.2":
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
-  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
+"@sinonjs/fake-timers@^10.0.2":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
+  integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
-    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/commons" "^3.0.0"
 
 "@types/babel__core@^7.1.14":
   version "7.1.20"
@@ -637,11 +686,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
-"@types/prettier@^2.1.5":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
-  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
-
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
@@ -705,15 +749,15 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-babel-jest@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.3.1.tgz#05c83e0d128cd48c453eea851482a38782249f44"
-  integrity sha512-aard+xnMoxgjwV70t0L6wkW/3HQQtV+O0PEimxKgzNqCJnbYmroPojdP2tqKSOAt8QAKV/uSZU8851M7B5+fcA==
+babel-jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
+  integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
   dependencies:
-    "@jest/transform" "^29.3.1"
+    "@jest/transform" "^29.7.0"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.1.1"
-    babel-preset-jest "^29.2.0"
+    babel-preset-jest "^29.6.3"
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
     slash "^3.0.0"
@@ -729,10 +773,10 @@ babel-plugin-istanbul@^6.1.1:
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^29.2.0:
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.2.0.tgz#23ee99c37390a98cfddf3ef4a78674180d823094"
-  integrity sha512-TnspP2WNiR3GLfCsUNHqeXw0RoQ2f9U5hQ5L3XFpwuO8htQmSrhh8qsB6vi5Yi8+kuynN1yjDjQsPfkebmB6ZA==
+babel-plugin-jest-hoist@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz#aadbe943464182a8922c3c927c3067ff40d24626"
+  integrity sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
@@ -757,12 +801,12 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
 
-babel-preset-jest@^29.2.0:
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.2.0.tgz#3048bea3a1af222e3505e4a767a974c95a7620dc"
-  integrity sha512-z9JmMJppMxNv8N7fNRHvhMg9cvIkMxQBXgFkane3yKVEvEOP+kB50lk8DFRvF9PGqbyXxlmebKWhuDORO8RgdA==
+babel-preset-jest@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz#fa05fa510e7d493896d7b0dd2033601c840f171c"
+  integrity sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==
   dependencies:
-    babel-plugin-jest-hoist "^29.2.0"
+    babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
@@ -924,6 +968,19 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+create-jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/create-jest/-/create-jest-29.7.0.tgz#a355c5b3cb1e1af02ba177fe7afd7feee49a5320"
+  integrity sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    jest-config "^29.7.0"
+    jest-util "^29.7.0"
+    prompts "^2.0.1"
+
 cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -945,10 +1002,10 @@ dedent-js@^1.0.1:
   resolved "https://registry.yarnpkg.com/dedent-js/-/dedent-js-1.0.1.tgz#bee5fb7c9e727d85dffa24590d10ec1ab1255305"
   integrity sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==
 
-dedent@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
-  integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
+dedent@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.1.tgz#4f3fc94c8b711e9bb2800d185cd6ad20f2a90aff"
+  integrity sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -964,6 +1021,11 @@ diff-sequences@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.3.1.tgz#104b5b95fe725932421a9c6e5b4bef84c3f2249e"
   integrity sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==
+
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 electron-to-chromium@^1.4.251:
   version "1.4.284"
@@ -1027,7 +1089,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^29.0.0, expect@^29.3.1:
+expect@^29.0.0:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.3.1.tgz#92877aad3f7deefc2e3f6430dd195b92295554a6"
   integrity sha512-gGb1yTgU30Q0O/tQq+z30KBWv24ApkMgFUpvKBkyLUBL68Wv8dHdJxTBZFl/iT8K/bqDHvUYRH6IIN3rToopPA==
@@ -1037,6 +1099,17 @@ expect@^29.0.0, expect@^29.3.1:
     jest-matcher-utils "^29.3.1"
     jest-message-util "^29.3.1"
     jest-util "^29.3.1"
+
+expect@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
+  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
+  dependencies:
+    "@jest/expect-utils" "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
@@ -1217,7 +1290,7 @@ istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3"
   integrity sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==
 
-istanbul-lib-instrument@^5.0.4, istanbul-lib-instrument@^5.1.0:
+istanbul-lib-instrument@^5.0.4:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz#d10c8885c2125574e1c231cacadf955675e1ce3d"
   integrity sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==
@@ -1227,6 +1300,17 @@ istanbul-lib-instrument@^5.0.4, istanbul-lib-instrument@^5.1.0:
     "@istanbuljs/schema" "^0.1.2"
     istanbul-lib-coverage "^3.2.0"
     semver "^6.3.0"
+
+istanbul-lib-instrument@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz#71e87707e8041428732518c6fb5211761753fbdf"
+  integrity sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==
+  dependencies:
+    "@babel/core" "^7.12.3"
+    "@babel/parser" "^7.14.7"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
 
 istanbul-lib-report@^3.0.0:
   version "3.0.0"
@@ -1254,82 +1338,83 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-changed-files@^29.2.0:
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.2.0.tgz#b6598daa9803ea6a4dce7968e20ab380ddbee289"
-  integrity sha512-qPVmLLyBmvF5HJrY7krDisx6Voi8DmlV3GZYX0aFNbaQsZeoz1hfxcCMbqDGuQCxU1dJy9eYc2xscE8QrCCYaA==
+jest-changed-files@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.7.0.tgz#1c06d07e77c78e1585d020424dedc10d6e17ac3a"
+  integrity sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==
   dependencies:
     execa "^5.0.0"
+    jest-util "^29.7.0"
     p-limit "^3.1.0"
 
-jest-circus@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.3.1.tgz#177d07c5c0beae8ef2937a67de68f1e17bbf1b4a"
-  integrity sha512-wpr26sEvwb3qQQbdlmei+gzp6yoSSoSL6GsLPxnuayZSMrSd5Ka7IjAvatpIernBvT2+Ic6RLTg+jSebScmasg==
+jest-circus@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.7.0.tgz#b6817a45fcc835d8b16d5962d0c026473ee3668a"
+  integrity sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==
   dependencies:
-    "@jest/environment" "^29.3.1"
-    "@jest/expect" "^29.3.1"
-    "@jest/test-result" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
-    dedent "^0.7.0"
+    dedent "^1.0.0"
     is-generator-fn "^2.0.0"
-    jest-each "^29.3.1"
-    jest-matcher-utils "^29.3.1"
-    jest-message-util "^29.3.1"
-    jest-runtime "^29.3.1"
-    jest-snapshot "^29.3.1"
-    jest-util "^29.3.1"
+    jest-each "^29.7.0"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
     p-limit "^3.1.0"
-    pretty-format "^29.3.1"
+    pretty-format "^29.7.0"
+    pure-rand "^6.0.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-cli@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.3.1.tgz#e89dff427db3b1df50cea9a393ebd8640790416d"
-  integrity sha512-TO/ewvwyvPOiBBuWZ0gm04z3WWP8TIK8acgPzE4IxgsLKQgb377NYGrQLc3Wl/7ndWzIH2CDNNsUjGxwLL43VQ==
+jest-cli@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.7.0.tgz#5592c940798e0cae677eec169264f2d839a37995"
+  integrity sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==
   dependencies:
-    "@jest/core" "^29.3.1"
-    "@jest/test-result" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/core" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
     chalk "^4.0.0"
+    create-jest "^29.7.0"
     exit "^0.1.2"
-    graceful-fs "^4.2.9"
     import-local "^3.0.2"
-    jest-config "^29.3.1"
-    jest-util "^29.3.1"
-    jest-validate "^29.3.1"
-    prompts "^2.0.1"
+    jest-config "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
     yargs "^17.3.1"
 
-jest-config@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.3.1.tgz#0bc3dcb0959ff8662957f1259947aedaefb7f3c6"
-  integrity sha512-y0tFHdj2WnTEhxmGUK1T7fgLen7YK4RtfvpLFBXfQkh2eMJAQq24Vx9472lvn5wg0MAO6B+iPfJfzdR9hJYalg==
+jest-config@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.7.0.tgz#bcbda8806dbcc01b1e316a46bb74085a84b0245f"
+  integrity sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/test-sequencer" "^29.3.1"
-    "@jest/types" "^29.3.1"
-    babel-jest "^29.3.1"
+    "@jest/test-sequencer" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    babel-jest "^29.7.0"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     deepmerge "^4.2.2"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
-    jest-circus "^29.3.1"
-    jest-environment-node "^29.3.1"
-    jest-get-type "^29.2.0"
-    jest-regex-util "^29.2.0"
-    jest-resolve "^29.3.1"
-    jest-runner "^29.3.1"
-    jest-util "^29.3.1"
-    jest-validate "^29.3.1"
+    jest-circus "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-runner "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
     micromatch "^4.0.4"
     parse-json "^5.2.0"
-    pretty-format "^29.3.1"
+    pretty-format "^29.7.0"
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
@@ -1343,67 +1428,82 @@ jest-diff@^29.3.1:
     jest-get-type "^29.2.0"
     pretty-format "^29.3.1"
 
-jest-docblock@^29.2.0:
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.2.0.tgz#307203e20b637d97cee04809efc1d43afc641e82"
-  integrity sha512-bkxUsxTgWQGbXV5IENmfiIuqZhJcyvF7tU4zJ/7ioTutdz4ToB5Yx6JOFBpgI+TphRY4lhOyCWGNH/QFQh5T6A==
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-docblock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.7.0.tgz#8fddb6adc3cdc955c93e2a87f61cfd350d5d119a"
+  integrity sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-29.3.1.tgz#bc375c8734f1bb96625d83d1ca03ef508379e132"
-  integrity sha512-qrZH7PmFB9rEzCSl00BWjZYuS1BSOH8lLuC0azQE9lQrAx3PWGKHTDudQiOSwIy5dGAJh7KA0ScYlCP7JxvFYA==
+jest-each@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-29.7.0.tgz#162a9b3f2328bdd991beaabffbb74745e56577d1"
+  integrity sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==
   dependencies:
-    "@jest/types" "^29.3.1"
+    "@jest/types" "^29.6.3"
     chalk "^4.0.0"
-    jest-get-type "^29.2.0"
-    jest-util "^29.3.1"
-    pretty-format "^29.3.1"
+    jest-get-type "^29.6.3"
+    jest-util "^29.7.0"
+    pretty-format "^29.7.0"
 
-jest-environment-node@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.3.1.tgz#5023b32472b3fba91db5c799a0d5624ad4803e74"
-  integrity sha512-xm2THL18Xf5sIHoU7OThBPtuH6Lerd+Y1NLYiZJlkE3hbE+7N7r8uvHIl/FkZ5ymKXJe/11SQuf3fv4v6rUMag==
+jest-environment-node@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.7.0.tgz#0b93e111dda8ec120bc8300e6d1fb9576e164376"
+  integrity sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==
   dependencies:
-    "@jest/environment" "^29.3.1"
-    "@jest/fake-timers" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
-    jest-mock "^29.3.1"
-    jest-util "^29.3.1"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
 
 jest-get-type@^29.2.0:
   version "29.2.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.2.0.tgz#726646f927ef61d583a3b3adb1ab13f3a5036408"
   integrity sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==
 
-jest-haste-map@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.3.1.tgz#af83b4347f1dae5ee8c2fb57368dc0bb3e5af843"
-  integrity sha512-/FFtvoG1xjbbPXQLFef+WSU4yrc0fc0Dds6aRPBojUid7qlPqZvxdUBA03HW0fnVHXVCnCdkuoghYItKNzc/0A==
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
+
+jest-haste-map@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.7.0.tgz#3c2396524482f5a0506376e6c858c3bbcc17b104"
+  integrity sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==
   dependencies:
-    "@jest/types" "^29.3.1"
+    "@jest/types" "^29.6.3"
     "@types/graceful-fs" "^4.1.3"
     "@types/node" "*"
     anymatch "^3.0.3"
     fb-watchman "^2.0.0"
     graceful-fs "^4.2.9"
-    jest-regex-util "^29.2.0"
-    jest-util "^29.3.1"
-    jest-worker "^29.3.1"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
     micromatch "^4.0.4"
     walker "^1.0.8"
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-leak-detector@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.3.1.tgz#95336d020170671db0ee166b75cd8ef647265518"
-  integrity sha512-3DA/VVXj4zFOPagGkuqHnSQf1GZBmmlagpguxEERO6Pla2g84Q1MaVIB3YMxgUaFIaYag8ZnTyQgiZ35YEqAQA==
+jest-leak-detector@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728"
+  integrity sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==
   dependencies:
-    jest-get-type "^29.2.0"
-    pretty-format "^29.3.1"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
 
 jest-matcher-utils@^29.3.1:
   version "29.3.1"
@@ -1414,6 +1514,16 @@ jest-matcher-utils@^29.3.1:
     jest-diff "^29.3.1"
     jest-get-type "^29.2.0"
     pretty-format "^29.3.1"
+
+jest-matcher-utils@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
+  integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
 
 jest-message-util@^29.3.1:
   version "29.3.1"
@@ -1430,132 +1540,143 @@ jest-message-util@^29.3.1:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.3.1.tgz#60287d92e5010979d01f218c6b215b688e0f313e"
-  integrity sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
   dependencies:
-    "@jest/types" "^29.3.1"
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-mock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
+  integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==
+  dependencies:
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
-    jest-util "^29.3.1"
+    jest-util "^29.7.0"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz#930b1546164d4ad5937d5540e711d4d38d4cad2e"
   integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
 
-jest-regex-util@^29.2.0:
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.2.0.tgz#82ef3b587e8c303357728d0322d48bbfd2971f7b"
-  integrity sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==
+jest-regex-util@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52"
+  integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
 
-jest-resolve-dependencies@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.3.1.tgz#a6a329708a128e68d67c49f38678a4a4a914c3bf"
-  integrity sha512-Vk0cYq0byRw2WluNmNWGqPeRnZ3p3hHmjJMp2dyyZeYIfiBskwq4rpiuGFR6QGAdbj58WC7HN4hQHjf2mpvrLA==
+jest-resolve-dependencies@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz#1b04f2c095f37fc776ff40803dc92921b1e88428"
+  integrity sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==
   dependencies:
-    jest-regex-util "^29.2.0"
-    jest-snapshot "^29.3.1"
+    jest-regex-util "^29.6.3"
+    jest-snapshot "^29.7.0"
 
-jest-resolve@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.3.1.tgz#9a4b6b65387a3141e4a40815535c7f196f1a68a7"
-  integrity sha512-amXJgH/Ng712w3Uz5gqzFBBjxV8WFLSmNjoreBGMqxgCz5cH7swmBZzgBaCIOsvb0NbpJ0vgaSFdJqMdT+rADw==
+jest-resolve@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.7.0.tgz#64d6a8992dd26f635ab0c01e5eef4399c6bcbc30"
+  integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
   dependencies:
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
-    jest-haste-map "^29.3.1"
+    jest-haste-map "^29.7.0"
     jest-pnp-resolver "^1.2.2"
-    jest-util "^29.3.1"
-    jest-validate "^29.3.1"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
     resolve "^1.20.0"
-    resolve.exports "^1.1.0"
+    resolve.exports "^2.0.0"
     slash "^3.0.0"
 
-jest-runner@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.3.1.tgz#a92a879a47dd096fea46bb1517b0a99418ee9e2d"
-  integrity sha512-oFvcwRNrKMtE6u9+AQPMATxFcTySyKfLhvso7Sdk/rNpbhg4g2GAGCopiInk1OP4q6gz3n6MajW4+fnHWlU3bA==
+jest-runner@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.7.0.tgz#809af072d408a53dcfd2e849a4c976d3132f718e"
+  integrity sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==
   dependencies:
-    "@jest/console" "^29.3.1"
-    "@jest/environment" "^29.3.1"
-    "@jest/test-result" "^29.3.1"
-    "@jest/transform" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/console" "^29.7.0"
+    "@jest/environment" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     emittery "^0.13.1"
     graceful-fs "^4.2.9"
-    jest-docblock "^29.2.0"
-    jest-environment-node "^29.3.1"
-    jest-haste-map "^29.3.1"
-    jest-leak-detector "^29.3.1"
-    jest-message-util "^29.3.1"
-    jest-resolve "^29.3.1"
-    jest-runtime "^29.3.1"
-    jest-util "^29.3.1"
-    jest-watcher "^29.3.1"
-    jest-worker "^29.3.1"
+    jest-docblock "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-leak-detector "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-resolve "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-util "^29.7.0"
+    jest-watcher "^29.7.0"
+    jest-worker "^29.7.0"
     p-limit "^3.1.0"
     source-map-support "0.5.13"
 
-jest-runtime@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.3.1.tgz#21efccb1a66911d6d8591276a6182f520b86737a"
-  integrity sha512-jLzkIxIqXwBEOZx7wx9OO9sxoZmgT2NhmQKzHQm1xwR1kNW/dn0OjxR424VwHHf1SPN6Qwlb5pp1oGCeFTQ62A==
+jest-runtime@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.7.0.tgz#efecb3141cf7d3767a3a0cc8f7c9990587d3d817"
+  integrity sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==
   dependencies:
-    "@jest/environment" "^29.3.1"
-    "@jest/fake-timers" "^29.3.1"
-    "@jest/globals" "^29.3.1"
-    "@jest/source-map" "^29.2.0"
-    "@jest/test-result" "^29.3.1"
-    "@jest/transform" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/globals" "^29.7.0"
+    "@jest/source-map" "^29.6.3"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
-    jest-haste-map "^29.3.1"
-    jest-message-util "^29.3.1"
-    jest-mock "^29.3.1"
-    jest-regex-util "^29.2.0"
-    jest-resolve "^29.3.1"
-    jest-snapshot "^29.3.1"
-    jest-util "^29.3.1"
+    jest-haste-map "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
-jest-snapshot@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.3.1.tgz#17bcef71a453adc059a18a32ccbd594b8cc4e45e"
-  integrity sha512-+3JOc+s28upYLI2OJM4PWRGK9AgpsMs/ekNryUV0yMBClT9B1DF2u2qay8YxcQd338PPYSFNb0lsar1B49sLDA==
+jest-snapshot@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"
+  integrity sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==
   dependencies:
     "@babel/core" "^7.11.6"
     "@babel/generator" "^7.7.2"
     "@babel/plugin-syntax-jsx" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
-    "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.3.3"
-    "@jest/expect-utils" "^29.3.1"
-    "@jest/transform" "^29.3.1"
-    "@jest/types" "^29.3.1"
-    "@types/babel__traverse" "^7.0.6"
-    "@types/prettier" "^2.1.5"
+    "@jest/expect-utils" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^29.3.1"
+    expect "^29.7.0"
     graceful-fs "^4.2.9"
-    jest-diff "^29.3.1"
-    jest-get-type "^29.2.0"
-    jest-haste-map "^29.3.1"
-    jest-matcher-utils "^29.3.1"
-    jest-message-util "^29.3.1"
-    jest-util "^29.3.1"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
     natural-compare "^1.4.0"
-    pretty-format "^29.3.1"
-    semver "^7.3.5"
+    pretty-format "^29.7.0"
+    semver "^7.5.3"
 
 jest-util@^29.0.0, jest-util@^29.3.1:
   version "29.3.1"
@@ -1569,51 +1690,63 @@ jest-util@^29.0.0, jest-util@^29.3.1:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-validate@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.3.1.tgz#d56fefaa2e7d1fde3ecdc973c7f7f8f25eea704a"
-  integrity sha512-N9Lr3oYR2Mpzuelp1F8negJR3YE+L1ebk1rYA5qYo9TTY3f9OWdptLoNSPP9itOCBIRBqjt/S5XHlzYglLN67g==
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
   dependencies:
-    "@jest/types" "^29.3.1"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
+jest-validate@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.7.0.tgz#7bf705511c64da591d46b15fce41400d52147d9c"
+  integrity sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==
+  dependencies:
+    "@jest/types" "^29.6.3"
     camelcase "^6.2.0"
     chalk "^4.0.0"
-    jest-get-type "^29.2.0"
+    jest-get-type "^29.6.3"
     leven "^3.1.0"
-    pretty-format "^29.3.1"
+    pretty-format "^29.7.0"
 
-jest-watcher@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.3.1.tgz#3341547e14fe3c0f79f9c3a4c62dbc3fc977fd4a"
-  integrity sha512-RspXG2BQFDsZSRKGCT/NiNa8RkQ1iKAjrO0//soTMWx/QUt+OcxMqMSBxz23PYGqUuWm2+m2mNNsmj0eIoOaFg==
+jest-watcher@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.7.0.tgz#7810d30d619c3a62093223ce6bb359ca1b28a2f2"
+  integrity sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==
   dependencies:
-    "@jest/test-result" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     emittery "^0.13.1"
-    jest-util "^29.3.1"
+    jest-util "^29.7.0"
     string-length "^4.0.1"
 
-jest-worker@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.3.1.tgz#e9462161017a9bb176380d721cab022661da3d6b"
-  integrity sha512-lY4AnnmsEWeiXirAIA0c9SDPbuCBq8IYuDVL8PMm0MZ2PEs2yPvRA/J64QBXuZp7CYKrDM/rmNrc9/i3KJQncw==
+jest-worker@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
+  integrity sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==
   dependencies:
     "@types/node" "*"
-    jest-util "^29.3.1"
+    jest-util "^29.7.0"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-29.3.1.tgz#c130c0d551ae6b5459b8963747fed392ddbde122"
-  integrity sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==
+jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
+  integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
   dependencies:
-    "@jest/core" "^29.3.1"
-    "@jest/types" "^29.3.1"
+    "@jest/core" "^29.7.0"
+    "@jest/types" "^29.6.3"
     import-local "^3.0.2"
-    jest-cli "^29.3.1"
+    jest-cli "^29.7.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1638,7 +1771,7 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
-json5@^2.2.1, json5@^2.2.2:
+json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -1866,6 +1999,15 @@ pretty-format@^29.0.0, pretty-format@^29.3.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -1873,6 +2015,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+pure-rand@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.4.tgz#50b737f6a925468679bff00ad20eade53f37d5c7"
+  integrity sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==
 
 react-is@^18.0.0:
   version "18.2.0"
@@ -1896,10 +2043,10 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve.exports@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
-  integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
+resolve.exports@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
+  integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
 resolve@^1.20.0:
   version "1.22.1"
@@ -1910,17 +2057,17 @@ resolve@^1.20.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-semver@7.x, semver@^7.3.5:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
-  dependencies:
-    lru-cache "^6.0.0"
-
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.5.3, semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -2070,18 +2217,18 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-ts-jest@^29.0.3:
-  version "29.0.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.3.tgz#63ea93c5401ab73595440733cefdba31fcf9cb77"
-  integrity sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==
+ts-jest@^29.1.1:
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.1.tgz#f58fe62c63caf7bfcc5cc6472082f79180f0815b"
+  integrity sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
     jest-util "^29.0.0"
-    json5 "^2.2.1"
+    json5 "^2.2.3"
     lodash.memoize "4.x"
     make-error "1.x"
-    semver "7.x"
+    semver "^7.5.3"
     yargs-parser "^21.0.1"
 
 type-detect@4.0.8:
@@ -2144,7 +2291,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-write-file-atomic@^4.0.1:
+write-file-atomic@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
   integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==


### PR DESCRIPTION
This is now working, but it relies on the `--experimental-vm-modules` NodeJS flag, the use of which generates bunch of warnings when running the tests.

The good part is that (besides having to convert to async-await syntax) no tests needed to change. So this new Prettier 3 seems to format everything exactly as Prettier 2 did.

Perhaps there is a better way though. Should try out [@prettier/sync](https://github.com/prettier/prettier-synchronized) which should eliminate the need to litter all tests with async-await. Maybe it also won't need this NodeJS flag.