### PR TITLE
Add mariadb, mysql, postgresql parsers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,9 @@ const createParser = (dialect: DialectName): Parser<Node> => ({
 export const parsers: Record<string, Parser<Node>> = {
   sqlite: createParser("sqlite"),
   bigquery: createParser("bigquery"),
+  mysql: createParser("mysql"),
+  mariadb: createParser("mariadb"),
+  postgresql: createParser("postgresql"),
 };
 
 export const printers: Record<string, Printer> = {


### PR DESCRIPTION
I saw that there was experimental support for the `mariadb`, `mysql`, `postgresql` parsers:

- https://github.com/nene/sql-parser-cst#features
- https://nene.github.io/sql-explorer/

Not sure if this is the only change that's required or if some parsing / formatting things will break in CI / build / runtime

Or maybe there's no appetite for this change currently, while these other dialects are experimental still...?