### PR TITLE
Format GROUP BY ALL for BigQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "prettier": "^3.0.3",
-    "sql-parser-cst": "^0.31.1"
+    "sql-parser-cst": "^0.32.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",

--- a/src/syntax/select.ts
+++ b/src/syntax/select.ts
@@ -180,6 +180,7 @@ export const selectMap: CstToDocMap<AllSelectNodes> = {
   group_by_cube: (print) => print(["cubeKw", "columns"]),
   group_by_grouping_sets: (print) =>
     print.spaced(["groupingSetsKw", "columns"]),
+  group_by_all: (print) => print(["allKw"]),
 
   // PARTITION BY clause
   partition_by_clause: (print) =>

--- a/test/select/select.test.ts
+++ b/test/select/select.test.ts
@@ -185,6 +185,28 @@ describe("select", () => {
       `);
     });
 
+    it(`formats short query with GROUP BY ALL`, async () => {
+      await testBigquery(dedent`
+        SELECT * FROM tbl GROUP BY ALL
+      `);
+    });
+
+    it(`formats long query with GROUP BY ALL`, async () => {
+      await testBigquery(dedent`
+        SELECT *
+        FROM my_table_name
+        GROUP BY ALL
+        HAVING my_table_name.col1 > 1
+        LIMIT 5
+      `);
+    });
+
+    it(`capitalizes GROUP BY all`, async () => {
+      expect(
+        await pretty(`SELECT * FROM tbl GROUP BY all`, { dialect: "bigquery" }),
+      ).toBe(`SELECT * FROM tbl GROUP BY ALL`);
+    });
+
     it(`formats QUALIFY clause`, async () => {
       await testBigquery(`SELECT * FROM tbl QUALIFY x > 10`);
     });


### PR DESCRIPTION
Add ability to format queries that contain a GROUP BY ALL clause. Apply after https://github.com/nene/sql-parser-cst/pull/101 has been released. Since that package needs to be released first, I was not able to update `yarn.lock`.