### PR TITLE
Format LANGUAGE SQL function/procedure bodies

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -2,7 +2,8 @@ import { Printer } from "prettier";
 import { Node } from "sql-parser-cst";
 import { embedJs } from "./embedJs";
 import { embedJson } from "./embedJson";
+import { embedSql } from "./embedSql";
 
 export const embed: NonNullable<Printer<Node>["embed"]> = (...args) => {
-  return embedJson(...args) || embedJs(...args);
+  return embedJson(...args) || embedJs(...args) || embedSql(...args);
 };

--- a/src/embedSql.ts
+++ b/src/embedSql.ts
@@ -51,7 +51,7 @@ export const embedSql: NonNullable<Printer<Node>["embed"]> = (path, options) => 
 
 const isSqlLanguageClause = (
   clause: CreateFunctionStmt["clauses"][0],
-): boolean => isLanguageClause(clause) && clause.name.name === "sql";
+): boolean => isLanguageClause(clause) && clause.name.name.toLowerCase() === "sql";
 
 const detectQuote = (
   node: StringLiteral,

--- a/src/embedSql.ts
+++ b/src/embedSql.ts
@@ -1,0 +1,56 @@
+import { Printer } from "prettier";
+import { CreateFunctionStmt, Node, StringLiteral } from "sql-parser-cst";
+import {
+  isAsClause,
+  isCreateFunctionStmt,
+  isLanguageClause,
+  isStringLiteral,
+} from "./node_utils";
+import { hardline, indent, stripTrailingHardline } from "./print_utils";
+
+export const embedSql: NonNullable<Printer<Node>["embed"]> = (path, options) => {
+  const node = path.node;
+  const parent = path.getParentNode(0);
+  const grandParent = path.getParentNode(1);
+
+  if (
+    isStringLiteral(node) &&
+    isAsClause(parent) &&
+    isCreateFunctionStmt(grandParent) &&
+    grandParent.clauses.some(isSqlLanguageClause)
+  ) {
+    return async (textToDoc) => {
+      const quote = detectQuote(node);
+
+      if (quote) {
+        const sql = await textToDoc(node.value, options);
+
+        return [
+          quote,
+          indent([hardline, stripTrailingHardline(sql)]),
+          hardline,
+          quote,
+        ];
+      }
+    };
+  }
+
+  return null;
+};
+
+const isSqlLanguageClause = (
+  clause: CreateFunctionStmt["clauses"][0],
+): boolean => isLanguageClause(clause) && clause.name.name === "sql";
+
+const detectQuote = (
+  node: StringLiteral,
+): string | undefined => {
+  const match = node.text.match(/^('|\$[^$]*\$)/);
+  const quote = match?.[1];
+
+  if (quote && node.text.endsWith(quote)) {
+    return quote;
+  }
+
+  return undefined;
+};

--- a/src/embedSql.ts
+++ b/src/embedSql.ts
@@ -46,11 +46,5 @@ const detectQuote = (
   node: StringLiteral,
 ): string | undefined => {
   const match = node.text.match(/^('|\$[^$]*\$)/);
-  const quote = match?.[1];
-
-  if (quote && node.text.endsWith(quote)) {
-    return quote;
-  }
-
-  return undefined;
+  return match?.[1];
 };

--- a/src/embedSql.ts
+++ b/src/embedSql.ts
@@ -1,8 +1,14 @@
 import { Printer } from "prettier";
-import { CreateFunctionStmt, Node, StringLiteral } from "sql-parser-cst";
+import {
+  CreateFunctionStmt,
+  CreateProcedureStmt,
+  Node,
+  StringLiteral
+} from "sql-parser-cst";
 import {
   isAsClause,
   isCreateFunctionStmt,
+  isCreateProcedureStmt,
   isLanguageClause,
   isStringLiteral,
 } from "./node_utils";
@@ -16,7 +22,7 @@ export const embedSql: NonNullable<Printer<Node>["embed"]> = (path, options) => 
   if (
     isStringLiteral(node) &&
     isAsClause(parent) &&
-    isCreateFunctionStmt(grandParent) &&
+    (isCreateFunctionStmt(grandParent) || isCreateProcedureStmt(grandParent)) &&
     grandParent.clauses.some(isSqlLanguageClause)
   ) {
     return async (textToDoc) => {
@@ -50,7 +56,7 @@ export const embedSql: NonNullable<Printer<Node>["embed"]> = (path, options) => 
 };
 
 const isSqlLanguageClause = (
-  clause: CreateFunctionStmt["clauses"][0],
+  clause: CreateFunctionStmt["clauses"][0] | CreateProcedureStmt['clauses'][0],
 ): boolean => isLanguageClause(clause) && clause.name.name.toLowerCase() === "sql";
 
 const detectQuote = (

--- a/test/ddl/function.test.ts
+++ b/test/ddl/function.test.ts
@@ -276,6 +276,27 @@ describe("function", () => {
         AS 'SELECT $$foo$$'
       `);
     });
+
+    it(`handles SQL language identifier case-insensitively`, async () => {
+      expect(
+        await pretty(
+          dedent`
+            CREATE FUNCTION my_func()
+            RETURNS INT64
+            LANGUAGE Sql
+            AS 'SELECT 1'
+          `,
+          { dialect: "postgresql" },
+        ),
+      ).toBe(dedent`
+        CREATE FUNCTION my_func()
+        RETURNS INT64
+        LANGUAGE Sql
+        AS $$
+          SELECT 1;
+        $$
+      `);
+    });
   });
 
   describe("drop function", () => {


### PR DESCRIPTION
This enables formatting function and procedue bodies where `LANGUAGE` is `sql`. More info: https://github.com/nene/sql-parser-cst/issues/126.

~~This is currently a draft because it's not handling escaped string literals correctly for string quoted functions. Also, I'm not certain if there's more work needed to format SQL functions in other dialects (eg MySQL?).~~ UPDATE:

1. Single-quoted function bodies are converted to dollar-quoted (`$$ .. $$`), to simplify formatting. If the function body contains `$$`, it's left as is.
2. No need to worry about MySQL: https://github.com/nene/prettier-plugin-sql-cst/pull/61#issuecomment-3764196413